### PR TITLE
improve text description in the blog post card

### DIFF
--- a/src/components/blog/GridItem.astro
+++ b/src/components/blog/GridItem.astro
@@ -46,7 +46,7 @@ const image = await findImage(post.image);
           {post.tags && post.tags.map((tag) => <code class="tag">{tag}</code>)}
         </div>
         <h2 class="text-2xl font-bold mb-2">{post.title}</h2>
-        <p class="text-gray-400 mb-4 text-long">{post.excerpt}</p>
+        <p class="text-gray-400 mb-4 text-long line-clamp-3">{post.excerpt}</p>
       </div>
     </a>
     <div class="flex items-center justify-between p-6">


### PR DESCRIPTION
Closes #103 

Following the recommendations of @xergioalex @arendondiosa  the improvement is made by limiting the text of the card description to 3 lines 

#### Desktop
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/d311baa3-8875-46ee-abda-a50cee43a6b8">

#### Mobile
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/a967af68-a299-426c-bd95-ed33204f27d5">

