### PR TITLE
Update codigo-conducta.md

### DIFF
--- a/src/pages/codigo-conducta.md
+++ b/src/pages/codigo-conducta.md
@@ -5,43 +5,43 @@ layout: '~/layouts/MarkdownLayout.astro'
 
 > Código de Conducta para la Comunidad de Tecnología Pereira Tech Talks
 
-_Última actualización_: Julio 31, 2024
+_Última actualización_: Agosto 8, 2024
 
 ## 1. Propósito
 
-Uno de los objetivos principales de **PereiraTechTalks** es ser inclusiva para el mayor número de contribuyentes, con la mayor diversidad de orígenes posibles. Como tal, estamos comprometidos a proporcionar un ambiente agradable, seguro y acogedor para todos, independientemente de su sexo, orientación sexual, capacidad, etnia, nivel socioeconómico, y religión (o falta de la misma).
+Uno de los objetivos principales de **Pereira Tech Talks** es ser inclusiva para el mayor número de contribuyentes, con la mayor diversidad de orígenes posibles. Como tal, estamos comprometidos a proporcionar un ambiente agradable, seguro y acogedor para todos, independientemente de su sexo, orientación sexual, capacidad, etnia, nivel socioeconómico y religión (o falta de la misma).
 
 Este código de conducta resume nuestras expectativas para todos los que participan en nuestra comunidad, así como las consecuencias para el comportamiento inaceptable.
 
-Invitamos a todos los que participan en **PereiraTechTalks** a que nos ayuden a crear experiencias seguras y positivas para todos.
+Invitamos a todos los que participan en **Pereira Tech Talks** a que nos ayuden a crear experiencias seguras y positivas para todos.
 
 ## 2. Ciudadanía de [Software / Cultura / Tecnología] Libre
 
-Un objetivo adicional de este Código de Conducta es aumentar la ciudadanía de [software / cultura / tecnología] libre mediante el fomento de los participantes a reconocer y fortalecer las relaciones entre nuestras acciones y sus efectos en nuestra comunidad.
+Un objetivo adicional de este Código de Conducta es aumentar la ciudadanía de [software/cultura/tecnología] libre, fomentando que los participantes reconozcan y fortalezcan las relaciones entre nuestras acciones y sus efectos en nuestra comunidad.
 
-Las comunidades reflejan las sociedades en las que existen y la acción positiva es fundamental para contrarrestar las muchas formas de desigualdad y los abusos de poder que existen en la sociedad.
+Las comunidades reflejan las sociedades en las que existen, y la acción positiva es fundamental para contrarrestar las muchas formas de desigualdad y los abusos de poder que existen en la sociedad.
 
-Si ves a alguien que está haciendo un esfuerzo adicional y significativo para asegurar que nuestra comunidad sea acogedora, amable, y esta persona alienta a todos los participantes a que contribuyan en la mayor medida, nos gustaría saber.
+Si ves a alguien que está haciendo un esfuerzo adicional y significativo para asegurar que nuestra comunidad sea acogedora y amable, y esta persona alienta a todos los participantes a que contribuyan en la mayor medida, nos gustaría saberlo.
 
 ## 3. Comportamiento esperado
 
 - Participa de manera auténtica y activa. Al hacerlo, contribuyes a la salud y la longevidad de esta comunidad.
 - Ejercita la consideración y el respeto en tus comunicaciones y acciones.
 - Intenta colaborar en lugar de generar conflicto.
-- Absténte de adoptar una conducta y un lenguaje degradantes, discriminatorios, abusivos o acosadores.
-- Sé consciente de tu entorno y de tus compañeros participantes. Alerta a líderes de la comunidad si notas una situación peligrosa, alguien en apuros, o violaciones de este Código de Conducta, incluso si parecen intrascendentes.
+- Abstente de adoptar una conducta y un lenguaje degradantes, discriminatorios, abusivos o acosadores.
+- Sé consciente de tu entorno y de tus compañeros participantes. Alerta a los líderes de la comunidad si notas una situación peligrosa, ves a alguien en apuros o detectas violaciones de este Código de Conducta, incluso si parecen intrascendentes.
 
 ## 4. Comportamiento inaceptable
 
-Comportamientos inaceptables incluyen: intimidación, acoso, abuso, discriminación, comunicación despectiva o degradante o acciones por cualquier participante en nuestra comunidad ya sea en internet, en todos los eventos relacionados y en las comunicaciones uno-a-uno que se realizan en el contexto de los negocios de la comunidad. Es posible que los lugares para eventos comunitarios sean de uso compartido con los miembros del público; por favor ser respetuoso con todos aquellos que los frecuentan.
+Comportamientos inaceptables incluyen: intimidación, acoso, abuso, discriminación, comunicación despectiva o degradante, o acciones por cualquier participante en nuestra comunidad, ya sea en internet, en todos los eventos relacionados y en las comunicaciones uno a uno que se realizan en el contexto de los negocios de la comunidad. Es posible que los lugares para eventos comunitarios sean de uso compartido con los miembros del público; por favor, sé respetuoso con todos aquellos que los frecuentan.
 
-El acoso incluye: comentarios nocivos o perjudiciales, verbales o escritos relacionados con el género, la orientación sexual, raza, religión, discapacidad; uso inadecuado de desnudos y / o imágenes sexuales en espacios públicos (incluyendo la presentación diapositivas); intimidación deliberada, acecho o seguimiento; fotografías o grabaciones acosadoras; interrupción sostenida de charlas y otros eventos; contacto físico inapropiado, y atención sexual no deseada.
+El acoso incluye: comentarios nocivos o perjudiciales, verbales o escritos, relacionados con el género, la orientación sexual, raza, religión, o discapacidad; uso inadecuado de desnudos y/o imágenes sexuales en espacios públicos (incluyendo las diapositivas de presentación); intimidación deliberada, acecho o seguimiento; fotografías o grabaciones acosadoras; interrupción sostenida de charlas y otros eventos; contacto físico inapropiado y atención sexual no deseada.
 
-## 5. Consecuencias de comportamiento inaceptable
+## 5. Consecuencias del comportamiento inaceptable
 
-El comportamiento inaceptable de cualquier miembro de la comunidad, incluyendo patrocinadores y aquellos con poder de decisión, no será tolerado.
+El comportamiento inaceptable de cualquier miembro de la comunidad, incluidos patrocinadores y aquellos con poder de decisión, no será tolerado.
 
-Se espera que personas a quienes se les solicite que detengan su comportamiento inaceptable lo hagan de manera inmediata.
+Se espera que las personas a quienes se les solicite que detengan su comportamiento inaceptable lo hagan de manera inmediata.
 
 Si un miembro de la comunidad participa en una conducta inaceptable, los organizadores comunitarios pueden tomar cualquier acción que consideren apropiada, hasta e incluyendo una prohibición temporal o expulsión permanente de la comunidad, sin previo aviso (y sin derecho a reembolso en el caso de un evento de pago).
 
@@ -49,34 +49,34 @@ Si un miembro de la comunidad participa en una conducta inaceptable, los organiz
 
 Si eres víctima o testigo de una conducta inaceptable, o tienes cualquier inquietud, por favor comunícate con un organizador del meetup lo antes posible.
 
-Adicionalmente, los organizadores comunitarios están disponibles para ayudar a miembros de la comunidad a contactar a la policía local o interceder para que víctimas de comportamiento inaceptable se sientan seguros,en el contexto de los eventos en persona, los organizadores también pueden intentar conseguir escoltas si un miembro de la comunidad lo siente necesario.
+Adicionalmente, los organizadores comunitarios están disponibles para ayudar a miembros de la comunidad a contactar a la policía local o interceder para que las víctimas de comportamiento inaceptable se sientan seguras. En el contexto de los eventos en persona, los organizadores también pueden intentar conseguir escoltas si un miembro de la comunidad lo siente necesario.
 
 ## 7. Políticas de moderación
 
-Estas son las políticas para mantener los estándares de conducta en nuestra comunidad en los canales de chat, meetups asociados, conferencias, grupos de estudio, y eventos virtuales.
+Estas son las políticas para mantener los estándares de conducta en nuestra comunidad en los canales de chat, meetups asociados, conferencias, grupos de estudio y eventos virtuales.
 
-Palabras que violen las normas de Código de Conducta, incluyendo comentarios odiosos, hirientes, opresivos, o excluyentes, no están permitidos. (Se permite las "malas palabras", pero nunca enfocadas hacia otro usuario/asistente, y nunca de una manera odiosa.)
-Comentarios que los organizadores encuentran inapropiados tampoco están permitidos, así aparezcan en el código de conducta o no.
-Los organizadores primero deberán responder a dichos comentarios con una advertencia.
-Si la advertencia es ignorada, el usuario/asistente será expulsado del canal para que evalúe su comportamiento, o deberá retirarse del lugar por 30 minutos en caso de eventos presenciales.
-Si el usuario/asistente regresa y continúa causando problemas, será expulsado del grupo/evento/lugar/Slack de forma indefinida.
-Los organizadores pueden retractar la expulsión a su discreción si esta se trata de una primera infracción y se ha ofrecido una disculpa sincera a quien ofendieron.
-Si un organizador expulsa a alguien y usted cree que fue una expulsión sin causa, contacte a ese organizador, o a un organizador diferente en privado. Quejas sobre expulsiones en medios abiertos, sociales, u otros canales no son permitidas y conllevaran a más expulsiones.
-Los organizadores se rigen por un nivel más alto que otros miembros de la comunidad. Si un organizador crea una situación inadecuada, este será juzgado con un estándar más alto.
+- Palabras que violen las normas de Código de Conducta, incluyendo comentarios odiosos, hirientes, opresivos o excluyentes, no están permitidos. (Se permiten las "malas palabras", pero nunca enfocadas hacia otro usuario/asistente, y nunca de una manera odiosa.)
+- Comentarios que los organizadores encuentren inapropiados tampoco están permitidos, así aparezcan en el código de conducta o no.
+- Los organizadores primero deberán responder a dichos comentarios con una advertencia.
+- Si la advertencia es ignorada, el usuario/asistente será expulsado del canal para que evalúe su comportamiento, o deberá retirarse del lugar por 30 minutos en caso de eventos presenciales.
+- Si el usuario/asistente regresa y continúa causando problemas, será expulsado del grupo/evento/lugar/Slack de forma indefinida.
+- Los organizadores pueden retractar la expulsión a su discreción si esta se trata de una primera infracción y se ha ofrecido una disculpa sincera a quien ofendieron.
+- Si un organizador expulsa a alguien y usted cree que fue una expulsión sin causa, contacte a ese organizador, o a un organizador diferente en privado. Quejas sobre expulsiones en medios abiertos, sociales u otros canales no son permitidas y conllevarán a más expulsiones.
+- Los organizadores se rigen por un nivel más alto que otros miembros de la comunidad. Si un organizador crea una situación inadecuada, este será juzgado con un estándar más alto.
 
-En la comunidad **PereiraTechTalks** nos esforzamos por ir un paso más allá y cuidar el uno del otro. No se limite a tratar de mostrar su excelencia técnica, trate también de ser la mejor persona posible. En particular, evite tocar temas ofensivos o sensibles, especialmente si están fuera del tema tratado; esto muy a menudo conduce a peleas innecesarias, sentimientos heridos, y a daños en la confianza; peor aún, puede conducir a que personas se alejen de la comunidad en su totalidad.
+En la comunidad **Pereira Tech Talks**, nos esforzamos por ir un paso más allá y cuidarnos los unos a los otros. No te limites a tratar de mostrar tu excelencia técnica, trata también de ser la mejor persona posible. En particular, evita tocar temas ofensivos o sensibles, especialmente si están fuera del tema tratado; esto muy a menudo conduce a peleas innecesarias, sentimientos heridos, y a daños en la confianza; peor aún, puede conducir a que personas se alejen de la comunidad en su totalidad.
 
-De la misma forma, si alguien está en desacuerdo con algo que usted dijo o hizo, resista el impulso de estar a la defensiva. Simplemente pare de hacer o decir lo que fuera que causó la queja y pida disculpas. Hay buenas probabilidades de que usted se pudo haber comunicado mejor, incluso si usted siente que fue malinterpretado o injustamente acusado, - recuerde que es su responsabilidad hacer que sus compañeras y compañeros de **PereiraTechTalks** estén cómodos.
+De la misma forma, si alguien está en desacuerdo con algo que dijiste o hiciste, resiste el impulso de estar a la defensiva. Simplemente para de hacer o decir lo que causó la queja y pide disculpas. Hay buenas probabilidades de que podrías haberte comunicado mejor, incluso si sientes que fuiste malinterpretado o injustamente acusado. Recuerda que es tu responsabilidad hacer que tus compañeras y compañeros de **Pereira Tech Talks** se sientan cómodos.
 
-Todo el mundo busca harmonía y todos estamos aquí, ante todo, porque queremos hablar de tecnologías que nos gustan. Por lo general, la gente está dispuesta a asumir buenas intenciones y perdonar, siempre y cuando usted gane su confianza y actúe de forma honrada.
-
-Adaptado de la Política de Moderación de Rust Readaptado del Código de Conducta de Colombia.dev
+Todo el mundo busca armonía y todos estamos aquí, ante todo, porque queremos hablar de tecnologías que nos gustan. Por lo general, la gente está dispuesta a asumir buenas intenciones y perdonar, siempre y cuando ganes su confianza y actúes de forma honrada.
 
 ## 8. Alcance
 
-Este Código de Conducta se aplica tanto dentro de los espacios de un proyecto como en espacios públicos cuando un individuo representa al proyecto o su comunidad. Ejemplos de representación del proyecto o comunidad incluyen el uso de una dirección de correo electrónico oficial del proyecto, publicaciones a través de una cuenta oficial de redes sociales, o actuando como un representante designado en un evento en línea o sin conexión. La representación de un proyecto puede ser clarificada más específicamente por los líderes del proyecto.
+Este Código de Conducta se aplica tanto dentro de los espacios de un proyecto como en espacios públicos cuando un individuo representa al proyecto o su comunidad. Ejemplos de representación del proyecto o comunidad incluyen el uso de una dirección de correo electrónico oficial del proyecto, publicaciones a través de una cuenta oficial de redes sociales, o actuar como un representante designado en un evento en línea o sin conexión. La representación de un proyecto puede ser clarificada más específicamente por los líderes del proyecto.
 
-Esperamos que todos los participantes de la comunidad (contribuyentes, pagados o de otro modo; patrocinadores; y otros invitados) se atengan a este Código de Conducta en todos los espacios virtuales y presenciales, así como en todas las comunicaciones de uno-a-uno pertinentes a los negocios de la comunidad.
+Este Código de Conducta también se aplica a todos los eventos organizados por **Pereira Tech Talks**, tanto virtuales como presenciales.
+
+Esperamos que todos los participantes de la comunidad (contribuyentes, pagados o de otro modo; patrocinadores; y otros invitados) se atengan a este Código de Conducta en todos los espacios virtuales y presenciales, así como en todas las comunicaciones de uno a uno pertinentes a los negocios de la comunidad.
 
 ## 9. Responsabilidad Ambiental
 
@@ -87,16 +87,18 @@ Como comunidad comprometida con el bienestar del planeta, reconocemos nuestra re
 - Optar por soluciones digitales en lugar de impresas siempre que sea posible.
 - Promover la conciencia ambiental entre nuestros miembros y participantes.
 - Colaborar con proveedores y socios que compartan nuestro compromiso con la sostenibilidad.
-- Creemos que cada pequeña acción cuenta y nos esforzamos por hacer una diferencia positiva para el medio ambiente en cada una de nuestras actividades.
+
+Creemos que cada pequeña acción cuenta y nos esforzamos por hacer una diferencia positiva para el medio ambiente en cada una de nuestras actividades.
 
 ## 10. Contacto
 
-- [Correo electrónico](mailto:pereiratechtalks@gmail.com):
+- [Correo electrónico](mailto:pereiratechtalks@gmail.com)
 - [Meetup.com](https://www.meetup.com/es-ES/Pereira-Tech-Talks/)
-- [Facebook](www.facebook.com/PerTechTalks)
+- [Facebook](https://www.facebook.com/PerTechTalks)
+- [Instagram](https://www.instagram.com/pertechtalks/)
 
-## 10. Licencia y atribución
+## 11. Licencia y atribución
 
 Este Código de Conducta se distribuye bajo una licencia [Creative Commons – ShareAlike (BY-SA)](https://creativecommons.org/licenses/by-sa/4.0/legalcode)
 
-Adaptado del Código de Conducta de Stumptown Syndicate Readaptado del [Código de Conducta de Colombia.dev](https://github.com/colombia-dev/codigo-de-conducta)
+Adaptado del Código de Conducta de Stumptown Syndicate y readaptado del [Código de Conducta de Colombia.dev](https://github.com/colombia-dev/codigo-de-conducta)


### PR DESCRIPTION
- Corrected typographical errors and formatting throughout the document.
- Standardized the use of the name "Pereira Tech Talks."
- Adjusted section numbering to eliminate duplicates.
- Improved wording for greater clarity and coherence.
- Included application of the Code of Conduct to all events organized by Pereira Tech Talks.
- Added Instagram link in the contact section.