### PR TITLE
📝 Add markdown standard document for Security Reports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+﻿# Pull Request
+
+To help us get this pull request reviewed and merged quickly, please be sure to include the following items:
+
+* [ ] Tests (if applicable)
+* [ ] Documentation (if applicable)
+* [ ] Changelog entry
+* [ ] A full explanation here in the PR description of the work done
+
+## PR Type
+What kind of change does this PR introduce?
+
+* [ ] Bugfix
+* [ ] Feature
+* [ ] Code style update (formatting, local variables)
+* [ ] Refactoring (no functional changes, no api changes)
+* [ ] Build related changes
+* [ ] CI related changes
+* [ ] Documentation content changes
+* [ ] Tests
+* [ ] Other
+
+## Backward Compatibility
+
+Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way?
+
+* [ ] Yes (backward compatible)
+* [ ] No (breaking changes)
+
+
+## What's new?
+- Describe what's new here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,31 +2,32 @@
 
 To help us get this pull request reviewed and merged quickly, please be sure to include the following items:
 
-* [ ] Tests (if applicable)
-* [ ] Documentation (if applicable)
-* [ ] Changelog entry
-* [ ] A full explanation here in the PR description of the work done
+- [ ] Tests (if applicable)
+- [ ] Documentation (if applicable)
+- [ ] Changelog entry
+- [ ] A full explanation here in the PR description of the work done
 
 ## PR Type
+
 What kind of change does this PR introduce?
 
-* [ ] Bugfix
-* [ ] Feature
-* [ ] Code style update (formatting, local variables)
-* [ ] Refactoring (no functional changes, no api changes)
-* [ ] Build related changes
-* [ ] CI related changes
-* [ ] Documentation content changes
-* [ ] Tests
-* [ ] Other
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Tests
+- [ ] Other
 
 ## Backward Compatibility
 
 Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way?
 
-* [ ] Yes (backward compatible)
-* [ ] No (breaking changes)
-
+- [ ] Yes (backward compatible)
+- [ ] No (breaking changes)
 
 ## What's new?
+
 - Describe what's new here.

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Step 5 - 🧪🧪🧪🧪 Check "BODY" length
         run: |
           MIN_BODY_LENGTH=30
-          PR_BODY='${{ github.event.pull_request.body }}'
+          PR_BODY="${{ github.event.pull_request.body }}"
           BODY_LENGTH=$(echo -n "$PR_BODY" | wc -c)
           if [ "$BODY_LENGTH" -lt "$MIN_BODY_LENGTH" ]; then
             echo "Pull request body is too short. It must have at least $MIN_BODY_LENGTH characters."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+﻿# Informar problemas de seguridad
+
+En PereiraTechTalks tomamos la seguridad muy en serio. Apreciamos tus esfuerzos por
+divulgar tus hallazgos de manera responsable, y haremos todo lo posible para
+reconocer tus contribuciones.
+
+## ¿Dónde debo informar los problemas de seguridad?
+
+Para darle tiempo a la comunidad de responder y actualizar, te instamos a que
+informes todos los problemas de seguridad de manera privada.
+
+Para informar un problema de seguridad en uno de nuestros proyectos, envíanos
+un correo directamente a **pereiratechtalks@gmail.com** e incluye la palabra "SEGURIDAD"
+en la línea de asunto.
+
+Este correo será entregado a nuestro de colaboradores con experiencia en Seguridad de Código Abierto.
+
+Después de la respuesta inicial a tu informe, el equipo te mantendrá informado
+sobre el progreso que se está haciendo para solucionar el problema y hacer un
+anuncio, y es posible que te soliciten información o guía adicional.


### PR DESCRIPTION
# Pull Request

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [X] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [X] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? 

* [X] Yes (backward compatible)
* [ ] No (breaking changes)


## What's new?
- Add a base security policy document, see for more [info](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
- Add a base pull request template document 
- Fix bug for the Pull Request Checker Workflow
