### PR TITLE
🐛 Fix bug for eol of the pr

### DIFF
--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Step 5 - 🧪🧪🧪🧪 Check "BODY" length
         run: |
           MIN_BODY_LENGTH=30
-          PR_BODY="${{ github.event.pull_request.body }}"
+          PR_BODY=$(printf "%s" "${{ github.event.pull_request.body }}")
           BODY_LENGTH=$(echo -n "$PR_BODY" | wc -c)
           if [ "$BODY_LENGTH" -lt "$MIN_BODY_LENGTH" ]; then
             echo "Pull request body is too short. It must have at least $MIN_BODY_LENGTH characters."


### PR DESCRIPTION
﻿## What is new?

- This try to fix the issue in step 5, which includes both single and double quotes, which are properly escaped when assigned to the `PR_BODY` variable. Needs testing, it could be done using one of the dependabot pr.
