### PR TITLE
[chore] removed telegram link

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -35,10 +35,6 @@ export const headerData = {
           href: 'https://chat.whatsapp.com/EzYAadvUWyVBHt3m1FU77U',
         },
         {
-          text: 'Telegram',
-          href: 'https://t.me/PerTechTalks',
-        },
-        {
           text: 'YouTube',
           href: 'https://www.youtube.com/@pereiratechtalks',
           target: '_blank',


### PR DESCRIPTION
As we are deprecating the Telegram community in favor of WhatsApp, we no longer need this link.

﻿## What is new?

- As we are deprecating the Telegram community in favor of WhatsApp, we no longer need this link.
