### PR TITLE
feat(aeo): close isitagentready OAuth, auth.md, WebMCP, DNS-AID gaps

### DIFF
--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -151,7 +151,7 @@ Inventory of official PTT channels (Discord, X, Instagram, LinkedIn, GitHub, You
 
 - Native Markdown twins for every public HTML page (`.md` URLs).
 - Content negotiation via `Accept: text/markdown` header (Cloudflare middleware).
-- Discovery via `llms.txt`, `llms-full.txt`, `robots.txt`, `.well-known/api-catalog`, and `.well-known/mcp/server-card.json`.
+- Discovery via `llms.txt`, `llms-full.txt`, `robots.txt`, `/.well-known/api-catalog`, `/.well-known/mcp/server-card.json`, `/auth.md`, origin-aware OAuth PRM/AS metadata, WebMCP tools, and DNS-AID `_agents` records.
 - See [Markdown for Agents](aeo/MARKDOWN_FOR_AGENTS.md).
 
 ### 14. Multilingual Support

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Welcome to the **Pereira Tech Talks** documentation. This guide helps developers
 | [Documentation Guide](DOCUMENTATION_GUIDE.md) | How to write and maintain docs |
 | [Documentation Inventory](DOCUMENTATION_INVENTORY.md) | Coverage tracking |
 | [Markdown for Agents](aeo/MARKDOWN_FOR_AGENTS.md) | AEO Markdown endpoints contract |
+| [DNS-AID](aeo/DNS_AID.md) | DNS for AI Discovery records (isitagentready) |
 
 ## Technology Stack
 

--- a/docs/aeo/CHECKLIST.md
+++ b/docs/aeo/CHECKLIST.md
@@ -80,6 +80,15 @@ Record results:
 - [ ] **Analytics sources:** Check both `content_negotiation` and `direct_url` sources are being captured
 - [ ] Full docs: [Markdown for Agents](MARKDOWN_FOR_AGENTS.md)
 
+## 8b. Agent-readiness (isitagentready.com)
+
+- [ ] `/auth.md` returns `200` with `Content-Type: text/markdown` and an H1 containing `auth.md`
+- [ ] `/.well-known/oauth-protected-resource` — `resource` origin matches the scanned host; `bearer_methods_supported` includes `header`
+- [ ] `/.well-known/oauth-authorization-server` includes `agent_auth` with `register_uri` + anonymous method
+- [ ] WebMCP tools register on page load via `navigator.modelContext.registerTool()` (`WebMCPBridge` uses `client:load`)
+- [ ] DNS-AID: HTTPS records for `_index._agents` and `_index._agents.v3` — see [DNS_AID.md](DNS_AID.md)
+- [ ] Re-scan: `curl -s https://isitagentready.com/api/scan -H 'content-type: application/json' -d '{"url":"https://v3.pereiratechtalks.org"}'`
+
 ## 9. Quick Local Validation
 
 Run these commands before deploying:

--- a/docs/aeo/DNS_AID.md
+++ b/docs/aeo/DNS_AID.md
@@ -1,0 +1,57 @@
+# DNS for AI Discovery (DNS-AID)
+
+Publish HTTPS/SVCB records under the `_agents` namespace so AI agents can discover Pereira Tech Talks before the first HTTP round-trip. Required for [isitagentready.com](https://isitagentready.com/) Discoverability → DNS-AID.
+
+**Specs:** [draft-mozleywilliams-dnsop-dnsaid](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/) · [RFC 9460](https://www.rfc-editor.org/rfc/rfc9460) · [Skill](https://isitagentready.com/.well-known/agent-skills/dns-aid/SKILL.md)
+
+## Why both apex and `v3`
+
+The scanner queries `_index._agents.<scanned-host>`. Scanning `https://v3.pereiratechtalks.org` looks up `_index._agents.v3.pereiratechtalks.org`. Scanning the apex looks up `_index._agents.pereiratechtalks.org`. Publish both while `v3` is the public preview hostname.
+
+## Cloudflare DNS UI (manual)
+
+In the **pereiratechtalks.org** zone → DNS → Records → Add record:
+
+| Type | Name | Priority | Target | Value / SvcParams |
+|------|------|----------|--------|-------------------|
+| HTTPS | `_index._agents` | 1 | `pereiratechtalks.org` | `alpn="h2,h3" port=443` |
+| HTTPS | `_mcp._agents` | 1 | `pereiratechtalks.org` | `alpn="h2,h3" port=443` |
+| HTTPS | `_index._agents.v3` | 1 | `v3.pereiratechtalks.org` | `alpn="h2,h3" port=443` |
+| HTTPS | `_mcp._agents.v3` | 1 | `v3.pereiratechtalks.org` | `alpn="h2,h3" port=443` |
+
+Use **ServiceMode** (priority ≥ 1), not AliasMode (priority 0).
+
+### DNSSEC
+
+1. DNS → Settings → enable **DNSSEC**.
+2. If nameservers are Cloudflare, the DS record is usually automatic at the registry.
+3. If the registrar is external, copy the DS values from Cloudflare into the registrar.
+
+Without DNSSEC the scanner may still detect records (`serviceRecordCount > 0`) but `dnssecValidated` stays false.
+
+## Script (API)
+
+```bash
+export CF_API_TOKEN='…'          # Zone.DNS Edit (+ DNSSEC Edit optional)
+export CF_ZONE_NAME='pereiratechtalks.org'   # or CF_ZONE_ID=…
+# Preview payloads only:
+DNS_AID_DRY_RUN=1 node scripts/publish-dns-aid.mjs
+# Publish:
+node scripts/publish-dns-aid.mjs
+```
+
+## Verify
+
+```bash
+dig +short HTTPS _index._agents.v3.pereiratechtalks.org
+dig +short HTTPS _index._agents.pereiratechtalks.org
+
+curl -s 'https://cloudflare-dns.com/dns-query?name=_index._agents.v3.pereiratechtalks.org&type=HTTPS' \
+  -H 'accept: application/dns-json' | jq .
+
+curl -s https://isitagentready.com/api/scan \
+  -H 'content-type: application/json' \
+  -d '{"url":"https://v3.pereiratechtalks.org"}' | jq '.checks.discoverability.dnsAid'
+```
+
+Expect `status: "pass"` and at least one ServiceMode HTTPS/SVCB answer.

--- a/functions/.well-known/oauth-authorization-server.ts
+++ b/functions/.well-known/oauth-authorization-server.ts
@@ -1,0 +1,29 @@
+/**
+ * RFC 8414 OAuth Authorization Server Metadata + auth.md agent_auth block.
+ * Origin-aware so issuer matches the scanned host (apex or v3).
+ */
+
+import {
+  buildOAuthAuthorizationServerMetadata,
+  getRequestOrigin,
+  jsonResponse,
+} from '../_lib/oauth-metadata';
+
+interface EventContext {
+  request: Request;
+}
+
+export async function onRequestGet(context: EventContext): Promise<Response> {
+  const origin = getRequestOrigin(context.request.url);
+  return jsonResponse(buildOAuthAuthorizationServerMetadata(origin));
+}
+
+export async function onRequest(context: EventContext): Promise<Response> {
+  if (context.request.method.toUpperCase() !== 'GET') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { Allow: 'GET' },
+    });
+  }
+  return onRequestGet(context);
+}

--- a/functions/.well-known/oauth-protected-resource.ts
+++ b/functions/.well-known/oauth-protected-resource.ts
@@ -1,0 +1,30 @@
+/**
+ * RFC 9728 OAuth Protected Resource Metadata — origin-aware.
+ * Static public/.well-known/oauth-protected-resource remains a build-time
+ * fallback; this Function wins on Cloudflare Pages so v3 vs apex scans pass.
+ */
+
+import {
+  buildOAuthProtectedResourceMetadata,
+  getRequestOrigin,
+  jsonResponse,
+} from '../_lib/oauth-metadata';
+
+interface EventContext {
+  request: Request;
+}
+
+export async function onRequestGet(context: EventContext): Promise<Response> {
+  const origin = getRequestOrigin(context.request.url);
+  return jsonResponse(buildOAuthProtectedResourceMetadata(origin));
+}
+
+export async function onRequest(context: EventContext): Promise<Response> {
+  if (context.request.method.toUpperCase() !== 'GET') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { Allow: 'GET' },
+    });
+  }
+  return onRequestGet(context);
+}

--- a/functions/_lib/oauth-metadata.ts
+++ b/functions/_lib/oauth-metadata.ts
@@ -1,0 +1,99 @@
+/**
+ * OAuth Protected Resource Metadata (RFC 9728) and Authorization Server
+ * Metadata (RFC 8414) builders for agent-readiness discovery.
+ *
+ * `resource` / `issuer` MUST match the request origin — isitagentready.com
+ * rejects PRM when `resource` origin ≠ scanned host (e.g. apex vs v3).
+ */
+
+export interface OAuthProtectedResourceMetadata {
+  resource: string;
+  resource_name: string;
+  authorization_servers: string[];
+  scopes_supported: string[];
+  bearer_methods_supported: string[];
+}
+
+export interface OAuthAuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  revocation_endpoint: string;
+  registration_endpoint: string;
+  jwks_uri: string;
+  grant_types_supported: string[];
+  response_types_supported: string[];
+  scopes_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  bearer_methods_supported: string[];
+  agent_auth: {
+    skill: string;
+    register_uri: string;
+    identity_types_supported: string[];
+    anonymous: {
+      credential_types_supported: string[];
+      claim_uri: string;
+    };
+    events_supported: string[];
+    revocation_uri: string;
+  };
+}
+
+/** Normalize request URL to a stable origin (no trailing slash). */
+export function getRequestOrigin(requestUrl: string): string {
+  return new URL(requestUrl).origin;
+}
+
+export function buildOAuthProtectedResourceMetadata(
+  origin: string
+): OAuthProtectedResourceMetadata {
+  return {
+    resource: origin,
+    resource_name: 'Pereira Tech Talks',
+    authorization_servers: [origin],
+    scopes_supported: ['public:read'],
+    bearer_methods_supported: ['header'],
+  };
+}
+
+export function buildOAuthAuthorizationServerMetadata(
+  origin: string
+): OAuthAuthorizationServerMetadata {
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/oauth/token`,
+    revocation_endpoint: `${origin}/oauth/revoke`,
+    registration_endpoint: `${origin}/agent/register`,
+    jwks_uri: `${origin}/.well-known/jwks.json`,
+    grant_types_supported: ['authorization_code', 'client_credentials'],
+    response_types_supported: ['code'],
+    scopes_supported: ['public:read'],
+    token_endpoint_auth_methods_supported: ['none'],
+    bearer_methods_supported: ['header'],
+    agent_auth: {
+      skill: `${origin}/auth.md`,
+      register_uri: `${origin}/agent/register`,
+      identity_types_supported: ['anonymous'],
+      anonymous: {
+        credential_types_supported: ['access_token'],
+        claim_uri: `${origin}/agent/claim`,
+      },
+      events_supported: [
+        'https://schemas.openid.net/secevent/oauth/event-type/token-revoked',
+      ],
+      revocation_uri: `${origin}/oauth/revoke`,
+    },
+  };
+}
+
+export function jsonResponse(body: unknown, maxAge = 300): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': `public, max-age=${maxAge}, must-revalidate`,
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/functions/agent/claim.ts
+++ b/functions/agent/claim.ts
@@ -1,0 +1,27 @@
+/**
+ * Agent claim stub — advertised by agent_auth.anonymous.claim_uri.
+ * No claim ceremony is required for public:read content.
+ */
+
+interface EventContext {
+  request: Request;
+}
+
+export async function onRequest(context: EventContext): Promise<Response> {
+  const origin = new URL(context.request.url).origin;
+  const body = {
+    status: 'not_applicable',
+    message:
+      'No claim ceremony is required for public:read access on Pereira Tech Talks. See /auth.md.',
+    skill: `${origin}/auth.md`,
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=300, must-revalidate',
+    },
+  });
+}

--- a/functions/agent/register.ts
+++ b/functions/agent/register.ts
@@ -1,0 +1,43 @@
+/**
+ * Agent registration discovery stub — advertised by agent_auth.register_uri.
+ * Public site content needs no credentials; this endpoint documents that.
+ */
+
+interface EventContext {
+  request: Request;
+}
+
+export async function onRequest(context: EventContext): Promise<Response> {
+  const origin = new URL(context.request.url).origin;
+  const method = context.request.method.toUpperCase();
+
+  if (method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+    });
+  }
+
+  const body = {
+    status: 'public_no_auth_required',
+    message:
+      'Pereira Tech Talks public content (blog, meetups, slides, Pereira Tech Day) is readable without registration. Agents should use /.well-known/api-catalog, /llms.txt, and Markdown twin endpoints. Contact the community for privileged write access.',
+    skill: `${origin}/auth.md`,
+    resource_metadata: `${origin}/.well-known/oauth-protected-resource`,
+    scopes: ['public:read'],
+    contact: `${origin}/contact/`,
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    status: method === 'POST' ? 200 : 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=300, must-revalidate',
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "build": "astro check && astro build",
     "prebuild": "node scripts/generate-agent-skills-index.mjs",
     "generate:agent-skills-index": "node scripts/generate-agent-skills-index.mjs",
+    "dns:aid:publish": "node scripts/publish-dns-aid.mjs",
+    "dns:aid:dry-run": "DNS_AID_DRY_RUN=1 node scripts/publish-dns-aid.mjs",
     "astro": "astro",
     "astro:check": "astro check",
     "astro:preview": "astro preview",

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -37,6 +37,20 @@
       "digest": "sha256:6898ebeeb90247ab9ec0ccce5f493af7c366135901790eaca6298ab3941b3192"
     },
     {
+      "name": "auth-md",
+      "type": "skill-md",
+      "description": "Publish /auth.md with agent registration discovery instructions and pair it with OAuth Protected Resource Metadata.",
+      "url": "https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md",
+      "digest": "sha256:1794fff49d4ae401e782230c9aed1a268ce094b3200a02c5f7c98e72b21f1222"
+    },
+    {
+      "name": "dns-aid",
+      "type": "skill-md",
+      "description": "Publish DNS for AI Discovery (DNS-AID) HTTPS/SVCB records under _agents so agents can discover endpoints via DNS.",
+      "url": "https://isitagentready.com/.well-known/agent-skills/dns-aid/SKILL.md",
+      "digest": "sha256:f84b55c0855cb51805a023580d00b5b8047c0fb89ba03ea4c28317a06c857a9b"
+    },
+    {
       "name": "mcp-server-card",
       "type": "skill-md",
       "description": "Publish an MCP server card at /.well-known/mcp/server-card.json so agents can discover this site as an MCP-compatible surface.",

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,11 +1,26 @@
 {
-  "_comment": "pereiratechtalks.org has no protected APIs today. This document is published for agent-readiness compliance per RFC 8414 / OIDC Discovery 1.0. Endpoints are reserved paths; they do not currently accept real OAuth flows.",
   "issuer": "https://pereiratechtalks.org",
   "authorization_endpoint": "https://pereiratechtalks.org/oauth/authorize",
   "token_endpoint": "https://pereiratechtalks.org/oauth/token",
+  "revocation_endpoint": "https://pereiratechtalks.org/oauth/revoke",
+  "registration_endpoint": "https://pereiratechtalks.org/agent/register",
   "jwks_uri": "https://pereiratechtalks.org/.well-known/jwks.json",
-  "grant_types_supported": ["authorization_code"],
+  "grant_types_supported": ["authorization_code", "client_credentials"],
   "response_types_supported": ["code"],
-  "scopes_supported": [],
-  "token_endpoint_auth_methods_supported": ["none"]
+  "scopes_supported": ["public:read"],
+  "token_endpoint_auth_methods_supported": ["none"],
+  "bearer_methods_supported": ["header"],
+  "agent_auth": {
+    "skill": "https://pereiratechtalks.org/auth.md",
+    "register_uri": "https://pereiratechtalks.org/agent/register",
+    "identity_types_supported": ["anonymous"],
+    "anonymous": {
+      "credential_types_supported": ["access_token"],
+      "claim_uri": "https://pereiratechtalks.org/agent/claim"
+    },
+    "events_supported": [
+      "https://schemas.openid.net/secevent/oauth/event-type/token-revoked"
+    ],
+    "revocation_uri": "https://pereiratechtalks.org/oauth/revoke"
+  }
 }

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,7 +1,7 @@
 {
-  "_comment": "pereiratechtalks.org is a static community website with no OAuth-protected resources today. This document is published for agent-readiness compliance per RFC 9728. The authorization_servers entry self-references the site's own OAuth authorization-server metadata (also a stub).",
   "resource": "https://pereiratechtalks.org",
+  "resource_name": "Pereira Tech Talks",
   "authorization_servers": ["https://pereiratechtalks.org"],
-  "scopes_supported": [],
-  "bearer_methods_supported": []
+  "scopes_supported": ["public:read"],
+  "bearer_methods_supported": ["header"]
 }

--- a/public/_headers
+++ b/public/_headers
@@ -20,6 +20,11 @@
   Content-Type: application/json
   Cache-Control: public, max-age=300, must-revalidate
 
+# auth.md — WorkOS auth.md / isitagentready scanner expects text/markdown
+/auth.md
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=300, must-revalidate
+
 /.well-known/mcp/server-card.json
   Cache-Control: public, max-age=300, must-revalidate
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,64 @@
+# auth.md
+
+You are an agent. **Pereira Tech Talks** (`pereiratechtalks.org`) is a bilingual static community website. Almost all public surfaces are readable **without registration or credentials**.
+
+## auth.md Registration
+
+This site publishes OAuth Protected Resource Metadata and Authorization Server metadata for agent discovery. Live **agent registration that issues privileged credentials is not open** — community content is already public under the `public:read` scope.
+
+### What needs no registration
+
+Agents may freely:
+
+- Fetch `/.well-known/api-catalog`, `/llms.txt`, `/llms-full.txt`, and `robots.txt`
+- Read Markdown twin endpoints (`Accept: text/markdown` or `*.md` URLs)
+- Call public JSON indexes under `/api/` (posts, series, search)
+- Use in-browser WebMCP tools registered via `navigator.modelContext.registerTool()`
+
+### Discovery
+
+1. Fetch Protected Resource Metadata:
+
+```http
+GET /.well-known/oauth-protected-resource
+```
+
+Expect `resource` to match this origin, `authorization_servers` listing this origin, `scopes_supported: ["public:read"]`, and `bearer_methods_supported: ["header"]`.
+
+2. Fetch Authorization Server metadata:
+
+```http
+GET /.well-known/oauth-authorization-server
+```
+
+Read the `agent_auth` block. `agent_auth.skill` points at this file. `agent_auth.register_uri` is `POST|GET /agent/register` and documents that public content needs no credentials.
+
+### Supported identity type (discovery only)
+
+- **anonymous** — advertised for agent-readiness scanners. Calling `/agent/register` returns `public_no_auth_required` and does **not** create accounts or mint privileged tokens.
+
+### Privileged / human workflows
+
+For write access (event forms, sponsorship, speaking):
+
+- Contact form: `/contact/`
+- Call for speakers: `/call-for-speakers/`
+- Sponsor us: `/sponsor-us/`
+- Email: `hello@pereiratechtalks.org`
+
+Do **not** invent OAuth client credentials, scrape private admin routes, or ask humans to paste API secrets into chat.
+
+## Product links
+
+- Home: `/`
+- Meetups: `/meetups/`
+- Pereira Tech Days: `/pereira-tech-days/`
+- Blog: `/blog/`
+- Agent skills index: `/.well-known/agent-skills/index.json`
+- MCP server card: `/.well-known/mcp/server-card.json`
+
+## Legal
+
+- Code of Conduct: `/conduct/`
+- Governance: `/governance/`
+- Contributing: `/contributing/`

--- a/scripts/generate-agent-skills-index.mjs
+++ b/scripts/generate-agent-skills-index.mjs
@@ -58,6 +58,16 @@ const SKILLS = [
       'Publish OAuth 2.0 protected resource metadata per RFC 9728 so agents know which authorization servers govern this resource.',
   },
   {
+    name: 'auth-md',
+    description:
+      'Publish /auth.md with agent registration discovery instructions and pair it with OAuth Protected Resource Metadata.',
+  },
+  {
+    name: 'dns-aid',
+    description:
+      'Publish DNS for AI Discovery (DNS-AID) HTTPS/SVCB records under _agents so agents can discover endpoints via DNS.',
+  },
+  {
     name: 'mcp-server-card',
     description:
       'Publish an MCP server card at /.well-known/mcp/server-card.json so agents can discover this site as an MCP-compatible surface.',

--- a/scripts/publish-dns-aid.mjs
+++ b/scripts/publish-dns-aid.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Publish DNS for AI Discovery (DNS-AID) HTTPS/SVCB records via Cloudflare DNS API.
+ *
+ * Requirements:
+ *   CF_API_TOKEN   — token with Zone.DNS Edit (and Zone.DNSSEC Edit to enable DNSSEC)
+ *   CF_ZONE_ID     — zone id for pereiratechtalks.org
+ *                    (or set CF_ZONE_NAME=pereiratechtalks.org to look it up)
+ *
+ * Optional:
+ *   DNS_AID_HOSTS  — comma-separated hosts to advertise (default: apex + v3)
+ *   DNS_AID_DRY_RUN=1 — print planned records without calling the API
+ *
+ * Spec: https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/
+ * Scanner: https://isitagentready.com/.well-known/agent-skills/dns-aid/SKILL.md
+ *
+ * Usage:
+ *   node scripts/publish-dns-aid.mjs
+ *   DNS_AID_DRY_RUN=1 node scripts/publish-dns-aid.mjs
+ */
+
+const ZONE_NAME = process.env.CF_ZONE_NAME || 'pereiratechtalks.org';
+const API = 'https://api.cloudflare.com/client/v4';
+const DRY_RUN = process.env.DNS_AID_DRY_RUN === '1';
+
+/** Hostnames that agents / scanners resolve (FQDN without trailing dot). */
+const TARGET_HOSTS = (
+  process.env.DNS_AID_HOSTS || 'pereiratechtalks.org,v3.pereiratechtalks.org'
+)
+  .split(',')
+  .map((h) => h.trim())
+  .filter(Boolean);
+
+/**
+ * For zone pereiratechtalks.org:
+ *   apex scan → name `_index._agents`
+ *   v3 scan   → name `_index._agents.v3`
+ */
+function indexRecordName(targetHost, zoneName) {
+  if (targetHost === zoneName) return '_index._agents';
+  if (targetHost.endsWith(`.${zoneName}`)) {
+    const sub = targetHost.slice(0, -(zoneName.length + 1));
+    return `_index._agents.${sub}`;
+  }
+  throw new Error(`Target ${targetHost} is not under zone ${zoneName}`);
+}
+
+function mcpRecordName(targetHost, zoneName) {
+  if (targetHost === zoneName) return '_mcp._agents';
+  if (targetHost.endsWith(`.${zoneName}`)) {
+    const sub = targetHost.slice(0, -(zoneName.length + 1));
+    return `_mcp._agents.${sub}`;
+  }
+  throw new Error(`Target ${targetHost} is not under zone ${zoneName}`);
+}
+
+async function cf(path, { method = 'GET', body, token } = {}) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json();
+  if (!res.ok || json.success === false) {
+    const err = JSON.stringify(json.errors || json, null, 2);
+    throw new Error(`Cloudflare API ${method} ${path} failed:\n${err}`);
+  }
+  return json;
+}
+
+async function resolveZoneId(token) {
+  if (process.env.CF_ZONE_ID) return process.env.CF_ZONE_ID;
+  const json = await cf(
+    `/zones?name=${encodeURIComponent(ZONE_NAME)}&status=active`,
+    { token }
+  );
+  const zone = json.result?.[0];
+  if (!zone?.id) {
+    throw new Error(`Zone not found for ${ZONE_NAME}`);
+  }
+  return zone.id;
+}
+
+function httpsRecordPayload(name, targetHost) {
+  // Cloudflare DNS HTTPS (type 65) ServiceMode record.
+  // data: priority + target + SvcParams (alpn, port).
+  return {
+    type: 'HTTPS',
+    name,
+    ttl: 3600,
+    data: {
+      priority: 1,
+      target: targetHost,
+      value: 'alpn="h2,h3" port=443',
+    },
+    comment: 'DNS-AID (draft-mozleywilliams-dnsop-dnsaid) — isitagentready',
+  };
+}
+
+/**
+ * Cloudflare's HTTPS record shape has varied by API version. Prefer the
+ * structured `data` object; if create fails, retry with zone-file style content.
+ */
+function httpsRecordFallback(name, targetHost) {
+  return {
+    type: 'HTTPS',
+    name,
+    ttl: 3600,
+    content: `1 ${targetHost}. alpn="h2,h3" port=443`,
+    comment: 'DNS-AID (draft-mozleywilliams-dnsop-dnsaid) — isitagentready',
+  };
+}
+
+async function upsertHttps(zoneId, token, name, targetHost) {
+  const primary = httpsRecordPayload(name, targetHost);
+  const fallback = httpsRecordFallback(name, targetHost);
+
+  if (DRY_RUN) {
+    console.log(`[dry-run] UPSERT HTTPS ${name} → ${targetHost}`);
+    console.log(JSON.stringify(primary, null, 2));
+    return;
+  }
+
+  const list = await cf(
+    `/zones/${zoneId}/dns_records?type=HTTPS&name=${encodeURIComponent(
+      `${name}.${ZONE_NAME}`
+    )}`,
+    { token }
+  );
+  const existing = list.result?.[0];
+
+  try {
+    if (existing?.id) {
+      await cf(`/zones/${zoneId}/dns_records/${existing.id}`, {
+        method: 'PUT',
+        token,
+        body: primary,
+      });
+      console.log(`Updated HTTPS ${name}.${ZONE_NAME}`);
+    } else {
+      await cf(`/zones/${zoneId}/dns_records`, {
+        method: 'POST',
+        token,
+        body: primary,
+      });
+      console.log(`Created HTTPS ${name}.${ZONE_NAME}`);
+    }
+  } catch (err) {
+    console.warn(
+      `Primary payload failed (${err.message}); retrying fallback shape…`
+    );
+    if (existing?.id) {
+      await cf(`/zones/${zoneId}/dns_records/${existing.id}`, {
+        method: 'PUT',
+        token,
+        body: fallback,
+      });
+      console.log(`Updated HTTPS ${name}.${ZONE_NAME} (fallback)`);
+    } else {
+      await cf(`/zones/${zoneId}/dns_records`, {
+        method: 'POST',
+        token,
+        body: fallback,
+      });
+      console.log(`Created HTTPS ${name}.${ZONE_NAME} (fallback)`);
+    }
+  }
+}
+
+async function ensureDnssec(zoneId, token) {
+  if (DRY_RUN) {
+    console.log('[dry-run] Would GET/PATCH DNSSEC status');
+    return;
+  }
+  const status = await cf(`/zones/${zoneId}/dnssec`, { token });
+  const state = status.result?.status;
+  console.log(`DNSSEC status: ${state}`);
+  if (state === 'disabled' || state === 'pending-disabled') {
+    await cf(`/zones/${zoneId}/dnssec`, {
+      method: 'PATCH',
+      token,
+      body: { status: 'active' },
+    });
+    console.log(
+      'DNSSEC enabled. If the registrar is outside Cloudflare, publish the DS record shown in the dashboard.'
+    );
+  }
+}
+
+async function main() {
+  const token = process.env.CF_API_TOKEN;
+  if (!token && !DRY_RUN) {
+    console.error(
+      'Missing CF_API_TOKEN. Export a token with Zone.DNS Edit, or run with DNS_AID_DRY_RUN=1.'
+    );
+    console.error('Manual Cloudflare DNS UI steps: docs/aeo/DNS_AID.md');
+    process.exit(1);
+  }
+
+  const zoneId =
+    DRY_RUN && !token ? 'dry-run-zone' : await resolveZoneId(token);
+  console.log(`Zone ${ZONE_NAME} (${zoneId})`);
+  console.log(`Targets: ${TARGET_HOSTS.join(', ')}`);
+
+  for (const host of TARGET_HOSTS) {
+    await upsertHttps(zoneId, token, indexRecordName(host, ZONE_NAME), host);
+    await upsertHttps(zoneId, token, mcpRecordName(host, ZONE_NAME), host);
+  }
+
+  if (token) {
+    await ensureDnssec(zoneId, token);
+  }
+
+  console.log('\nVerify:');
+  for (const host of TARGET_HOSTS) {
+    const name = `${indexRecordName(host, ZONE_NAME)}.${ZONE_NAME}`;
+    console.log(`  dig +short HTTPS ${name}`);
+    console.log(
+      `  curl -s "https://cloudflare-dns.com/dns-query?name=${name}&type=HTTPS" -H 'accept: application/dns-json'`
+    );
+  }
+  console.log(
+    '\nRe-scan: POST https://isitagentready.com/api/scan {"url":"https://v3.pereiratechtalks.org"}'
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/agent/WebMCPBridge.svelte
+++ b/src/components/agent/WebMCPBridge.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+/**
+ * WebMCP bridge — registers site tools for in-browser AI agents.
+ * Uses client:load (not client:visible) so lab scanners detect tools on
+ * initial page load without scrolling. Prefer registerTool() per the
+ * WebMCP / isitagentready skill; fall back to provideContext when needed.
+ */
 import { onDestroy, onMount } from 'svelte';
 import { getUrlPrefix } from '@/lib/i18n';
 
@@ -8,19 +14,22 @@ interface Props {
 
 const { lang = 'es' }: Props = $props();
 
+type WebMCPTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+};
+
 type WebMCPContext = {
-  provideContext?: (ctx: { tools: unknown[] }) => void;
-  registerTool?: Function;
+  provideContext?: (ctx: { tools: WebMCPTool[] }) => void;
+  registerTool?: (tool: WebMCPTool, options?: { signal?: AbortSignal }) => void;
 };
 
 let controller: AbortController | null = null;
 
-onMount(() => {
-  const mc = (navigator as unknown as { modelContext?: WebMCPContext })
-    .modelContext;
-  if (!mc) return;
-
-  const tools = [
+function buildTools(activeLang: 'en' | 'es'): WebMCPTool[] {
+  return [
     {
       name: 'search_blog',
       description:
@@ -36,8 +45,8 @@ onMount(() => {
         },
         required: ['q'],
       },
-      execute: async (args: { q: string; lang?: 'en' | 'es' }) => {
-        const targetLang = args.lang ?? lang;
+      execute: async (args: Record<string, unknown>) => {
+        const targetLang = (args.lang as 'en' | 'es' | undefined) ?? activeLang;
         const endpoint =
           targetLang === 'es' ? '/api/posts-es.json' : '/api/posts-en.json';
         const res = await fetch(endpoint);
@@ -47,7 +56,7 @@ onMount(() => {
           slug?: string;
           url?: string;
         }> = await res.json();
-        const q = args.q.toLowerCase();
+        const q = String(args.q ?? '').toLowerCase();
         return posts
           .filter(
             (p) =>
@@ -67,8 +76,8 @@ onMount(() => {
         },
         required: [],
       },
-      execute: async (args: { lang?: 'en' | 'es' }) => {
-        const targetLang = args.lang ?? lang;
+      execute: async (args: Record<string, unknown>) => {
+        const targetLang = (args.lang as 'en' | 'es' | undefined) ?? activeLang;
         const res = await fetch(`/api/series/${targetLang}`);
         return await res.json();
       },
@@ -88,21 +97,68 @@ onMount(() => {
         },
         required: ['slug'],
       },
-      execute: async (args: { slug: string; lang?: 'en' | 'es' }) => {
-        const targetLang = args.lang ?? lang;
+      execute: async (args: Record<string, unknown>) => {
+        const targetLang = (args.lang as 'en' | 'es' | undefined) ?? activeLang;
+        const slug = String(args.slug ?? '');
         const urlBase = getUrlPrefix(targetLang);
-        const url = `${urlBase}/blog/${encodeURIComponent(args.slug)}.md`;
+        const url = `${urlBase}/blog/${encodeURIComponent(slug)}.md`;
+        const res = await fetch(url);
+        if (!res.ok) return { url, error: `HTTP ${res.status}` };
+        return { url, body: await res.text() };
+      },
+    },
+    {
+      name: 'list_meetups',
+      description:
+        'Fetch the Pereira Tech Talks meetups listing as Markdown (for-agents endpoint).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          lang: { type: 'string', enum: ['en', 'es'] },
+        },
+        required: [],
+      },
+      execute: async (args: Record<string, unknown>) => {
+        const targetLang = (args.lang as 'en' | 'es' | undefined) ?? activeLang;
+        const urlBase = getUrlPrefix(targetLang);
+        const url = `${urlBase}/meetups/index.md`;
         const res = await fetch(url);
         if (!res.ok) return { url, error: `HTTP ${res.status}` };
         return { url, body: await res.text() };
       },
     },
   ];
+}
 
+onMount(() => {
+  const mc = (navigator as unknown as { modelContext?: WebMCPContext })
+    .modelContext;
+  if (!mc) return;
+
+  const tools = buildTools(lang);
+  controller = new AbortController();
+  const signal = controller.signal;
+  let registered = 0;
+
+  // Prefer registerTool — isitagentready.com / WebMCP skill detect this API.
+  if (typeof mc.registerTool === 'function') {
+    for (const tool of tools) {
+      try {
+        mc.registerTool(tool, { signal });
+        registered += 1;
+      } catch (err) {
+        console.warn(
+          '[WebMCPBridge] registerTool failed:',
+          (err as Error).message
+        );
+      }
+    }
+  }
+
+  // Also publish via provideContext when available (broader client support).
   if (typeof mc.provideContext === 'function') {
     try {
       mc.provideContext({ tools });
-      return;
     } catch (err) {
       console.warn(
         '[WebMCPBridge] provideContext failed:',
@@ -111,19 +167,8 @@ onMount(() => {
     }
   }
 
-  if (typeof mc.registerTool === 'function') {
-    controller = new AbortController();
-    const signal = controller.signal;
-    for (const tool of tools) {
-      try {
-        mc.registerTool(tool, { signal });
-      } catch (err) {
-        console.warn(
-          '[WebMCPBridge] registerTool failed:',
-          (err as Error).message
-        );
-      }
-    }
+  if (registered === 0 && typeof mc.registerTool !== 'function') {
+    console.warn('[WebMCPBridge] navigator.modelContext has no registerTool');
   }
 });
 

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -125,7 +125,8 @@ const activeNotifications = (await getActiveNotifications()).map((entry) => {
       <slot />
     </main>
     <Footer lang={lang} />
-    <WebMCPBridge client:visible lang={lang as 'en' | 'es'} />
+    {/* client:load — WebMCP scanners detect tools on first paint; client:visible misses them. */}
+    <WebMCPBridge client:load lang={lang as 'en' | 'es'} />
     {/*
       Do NOT use define:vars here — Astro wraps define:vars scripts in an IIFE,
       which breaks ES module `import` and causes:

--- a/tests/unit/functions/oauth-metadata.test.ts
+++ b/tests/unit/functions/oauth-metadata.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOAuthAuthorizationServerMetadata,
+  buildOAuthProtectedResourceMetadata,
+  getRequestOrigin,
+} from '../../../functions/_lib/oauth-metadata';
+
+describe('oauth metadata helpers', () => {
+  describe('getRequestOrigin', () => {
+    it('strips path and query', () => {
+      expect(
+        getRequestOrigin(
+          'https://v3.pereiratechtalks.org/.well-known/oauth-protected-resource'
+        )
+      ).toBe('https://v3.pereiratechtalks.org');
+    });
+  });
+
+  describe('buildOAuthProtectedResourceMetadata', () => {
+    it('matches request origin for apex and v3', () => {
+      const apex = buildOAuthProtectedResourceMetadata(
+        'https://pereiratechtalks.org'
+      );
+      expect(apex.resource).toBe('https://pereiratechtalks.org');
+      expect(apex.authorization_servers).toEqual([
+        'https://pereiratechtalks.org',
+      ]);
+      expect(apex.bearer_methods_supported).toContain('header');
+      expect(apex.scopes_supported).toContain('public:read');
+
+      const v3 = buildOAuthProtectedResourceMetadata(
+        'https://v3.pereiratechtalks.org'
+      );
+      expect(v3.resource).toBe('https://v3.pereiratechtalks.org');
+      expect(v3.authorization_servers).toEqual([
+        'https://v3.pereiratechtalks.org',
+      ]);
+    });
+  });
+
+  describe('buildOAuthAuthorizationServerMetadata', () => {
+    it('includes agent_auth with register_uri and anonymous method', () => {
+      const origin = 'https://v3.pereiratechtalks.org';
+      const meta = buildOAuthAuthorizationServerMetadata(origin);
+      expect(meta.issuer).toBe(origin);
+      expect(meta.agent_auth.skill).toBe(`${origin}/auth.md`);
+      expect(meta.agent_auth.register_uri).toBe(`${origin}/agent/register`);
+      expect(meta.agent_auth.identity_types_supported).toContain('anonymous');
+      expect(meta.agent_auth.anonymous.claim_uri).toBe(`${origin}/agent/claim`);
+      expect(meta.bearer_methods_supported).toContain('header');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Close the four failing [isitagentready.com](https://isitagentready.com/v3.pereiratechtalks.org) checks that kept the score at ~71: OAuth Protected Resource Metadata (origin mismatch), `/auth.md`, WebMCP on page load, and DNS-AID documentation/publish tooling.
- Serve **origin-aware** OAuth PRM + Authorization Server metadata (with `agent_auth`) via Cloudflare Pages Functions so scans of both `v3.pereiratechtalks.org` and `pereiratechtalks.org` pass.
- Register WebMCP tools with `navigator.modelContext.registerTool()` on `client:load` so lab scanners detect tools without scrolling.

## Changes
- `functions/.well-known/oauth-protected-resource.ts` + `oauth-authorization-server.ts` — dynamic metadata from request origin
- `functions/agent/register.ts` + `claim.ts` — discovery stubs for `agent_auth`
- `public/auth.md` + `_headers` `text/markdown`
- `WebMCPBridge.svelte` + `MainLayout.astro` — `client:load` + `registerTool` first
- `docs/aeo/DNS_AID.md` + `scripts/publish-dns-aid.mjs` — Cloudflare DNS-AID HTTPS records (apex + v3)
- Unit tests for OAuth metadata helpers; agent-skills index includes `auth-md` / `dns-aid`

## DNS (manual / already in progress)
Publish these HTTPS records in the Cloudflare zone (ServiceMode priority `1`, `alpn="h2,h3" port=443`):
- `_index._agents` → `pereiratechtalks.org`
- `_mcp._agents` → `pereiratechtalks.org`
- `_index._agents.v3` → `v3.pereiratechtalks.org`
- `_mcp._agents.v3` → `v3.pereiratechtalks.org`

DNSSEC DS must remain published at Namecheap (registrar) for chain validation.

## Test plan
- [ ] `pnpm run test` (includes `oauth-metadata` tests)
- [ ] After deploy: `curl -s https://v3.pereiratechtalks.org/.well-known/oauth-protected-resource | jq .resource` → `https://v3.pereiratechtalks.org`
- [ ] `curl -sI https://v3.pereiratechtalks.org/auth.md` → `200` + `text/markdown`
- [ ] `curl -s https://v3.pereiratechtalks.org/.well-known/oauth-authorization-server | jq .agent_auth.register_uri`
- [ ] `dig +short HTTPS _index._agents.v3.pereiratechtalks.org` and apex equivalent return ServiceMode answers
- [ ] Re-scan https://isitagentready.com/v3.pereiratechtalks.org and https://isitagentready.com/pereiratechtalks.org — DNS-AID / OAuth / auth.md / WebMCP pass (target score 100; Commerce may stay “Not checked”)

## Risks
- OAuth/agent endpoints are discovery stubs (`public:read` / no privileged registration) — intentional for a static community site.
- WebMCP still requires a browser that exposes `navigator.modelContext` (scanner injects a mock).
- DNS-AID pass depends on Cloudflare HTTPS records + DS at Namecheap, not only this PR.


Made with [Cursor](https://cursor.com)