### PR TITLE
fix(aeo): top-level agent_auth.claim_uri for isitagentready authMd

### DIFF
--- a/functions/.well-known/oauth-authorization-server.ts
+++ b/functions/.well-known/oauth-authorization-server.ts
@@ -18,12 +18,18 @@ export async function onRequestGet(context: EventContext): Promise<Response> {
   return jsonResponse(buildOAuthAuthorizationServerMetadata(origin));
 }
 
+export async function onRequestHead(context: EventContext): Promise<Response> {
+  const origin = getRequestOrigin(context.request.url);
+  const body = jsonResponse(buildOAuthAuthorizationServerMetadata(origin));
+  return new Response(null, { status: 200, headers: body.headers });
+}
+
 export async function onRequest(context: EventContext): Promise<Response> {
-  if (context.request.method.toUpperCase() !== 'GET') {
-    return new Response('Method Not Allowed', {
-      status: 405,
-      headers: { Allow: 'GET' },
-    });
-  }
-  return onRequestGet(context);
+  const method = context.request.method.toUpperCase();
+  if (method === 'HEAD') return onRequestHead(context);
+  if (method === 'GET') return onRequestGet(context);
+  return new Response('Method Not Allowed', {
+    status: 405,
+    headers: { Allow: 'GET, HEAD' },
+  });
 }

--- a/functions/.well-known/oauth-protected-resource.ts
+++ b/functions/.well-known/oauth-protected-resource.ts
@@ -19,12 +19,18 @@ export async function onRequestGet(context: EventContext): Promise<Response> {
   return jsonResponse(buildOAuthProtectedResourceMetadata(origin));
 }
 
+export async function onRequestHead(context: EventContext): Promise<Response> {
+  const origin = getRequestOrigin(context.request.url);
+  const body = jsonResponse(buildOAuthProtectedResourceMetadata(origin));
+  return new Response(null, { status: 200, headers: body.headers });
+}
+
 export async function onRequest(context: EventContext): Promise<Response> {
-  if (context.request.method.toUpperCase() !== 'GET') {
-    return new Response('Method Not Allowed', {
-      status: 405,
-      headers: { Allow: 'GET' },
-    });
-  }
-  return onRequestGet(context);
+  const method = context.request.method.toUpperCase();
+  if (method === 'HEAD') return onRequestHead(context);
+  if (method === 'GET') return onRequestGet(context);
+  return new Response('Method Not Allowed', {
+    status: 405,
+    headers: { Allow: 'GET, HEAD' },
+  });
 }

--- a/functions/_lib/oauth-metadata.ts
+++ b/functions/_lib/oauth-metadata.ts
@@ -4,6 +4,10 @@
  *
  * `resource` / `issuer` MUST match the request origin — isitagentready.com
  * rejects PRM when `resource` origin ≠ scanned host (e.g. apex vs v3).
+ *
+ * auth.md scanners require top-level `agent_auth.claim_uri` when
+ * `identity_types_supported` includes `anonymous` (nested-only fails with
+ * "anonymous registration requires claim_uri").
  */
 
 export interface OAuthProtectedResourceMetadata {
@@ -29,6 +33,13 @@ export interface OAuthAuthorizationServerMetadata {
   agent_auth: {
     skill: string;
     register_uri: string;
+    /** WorkOS / clawhub alias for register_uri */
+    identity_endpoint: string;
+    /** Required at top level for anonymous by isitagentready authMd check */
+    claim_uri: string;
+    /** WorkOS / clawhub alias for claim_uri */
+    claim_endpoint: string;
+    claim_complete_uri: string;
     identity_types_supported: string[];
     anonymous: {
       credential_types_supported: string[];
@@ -59,12 +70,17 @@ export function buildOAuthProtectedResourceMetadata(
 export function buildOAuthAuthorizationServerMetadata(
   origin: string
 ): OAuthAuthorizationServerMetadata {
+  const registerUri = `${origin}/agent/register`;
+  const claimUri = `${origin}/agent/claim`;
+  const claimCompleteUri = `${origin}/agent/claim/complete`;
+  const revocationUri = `${origin}/oauth/revoke`;
+
   return {
     issuer: origin,
     authorization_endpoint: `${origin}/oauth/authorize`,
     token_endpoint: `${origin}/oauth/token`,
-    revocation_endpoint: `${origin}/oauth/revoke`,
-    registration_endpoint: `${origin}/agent/register`,
+    revocation_endpoint: revocationUri,
+    registration_endpoint: registerUri,
     jwks_uri: `${origin}/.well-known/jwks.json`,
     grant_types_supported: ['authorization_code', 'client_credentials'],
     response_types_supported: ['code'],
@@ -73,16 +89,20 @@ export function buildOAuthAuthorizationServerMetadata(
     bearer_methods_supported: ['header'],
     agent_auth: {
       skill: `${origin}/auth.md`,
-      register_uri: `${origin}/agent/register`,
+      register_uri: registerUri,
+      identity_endpoint: registerUri,
+      claim_uri: claimUri,
+      claim_endpoint: claimUri,
+      claim_complete_uri: claimCompleteUri,
       identity_types_supported: ['anonymous'],
       anonymous: {
         credential_types_supported: ['access_token'],
-        claim_uri: `${origin}/agent/claim`,
+        claim_uri: claimUri,
       },
       events_supported: [
         'https://schemas.openid.net/secevent/oauth/event-type/token-revoked',
       ],
-      revocation_uri: `${origin}/oauth/revoke`,
+      revocation_uri: revocationUri,
     },
   };
 }

--- a/functions/agent/claim/complete.ts
+++ b/functions/agent/claim/complete.ts
@@ -1,0 +1,27 @@
+/**
+ * Agent claim-complete stub — advertised by agent_auth.claim_complete_uri.
+ * No OTP ceremony is required for public:read content.
+ */
+
+interface EventContext {
+  request: Request;
+}
+
+export async function onRequest(context: EventContext): Promise<Response> {
+  const origin = new URL(context.request.url).origin;
+  const body = {
+    status: 'not_applicable',
+    message:
+      'No claim-complete ceremony is required for public:read access on Pereira Tech Talks. See /auth.md.',
+    skill: `${origin}/auth.md`,
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=300, must-revalidate',
+    },
+  });
+}

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -13,6 +13,10 @@
   "agent_auth": {
     "skill": "https://pereiratechtalks.org/auth.md",
     "register_uri": "https://pereiratechtalks.org/agent/register",
+    "identity_endpoint": "https://pereiratechtalks.org/agent/register",
+    "claim_uri": "https://pereiratechtalks.org/agent/claim",
+    "claim_endpoint": "https://pereiratechtalks.org/agent/claim",
+    "claim_complete_uri": "https://pereiratechtalks.org/agent/claim/complete",
     "identity_types_supported": ["anonymous"],
     "anonymous": {
       "credential_types_supported": ["access_token"],

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,19 +1,14 @@
 # auth.md
 
-You are an agent. **Pereira Tech Talks** (`pereiratechtalks.org`) is a bilingual static community website. Almost all public surfaces are readable **without registration or credentials**.
+You are an agent. **Pereira Tech Talks** is a bilingual static community website. Public content is readable under the `public:read` scope **without privileged credentials**.
 
 ## auth.md Registration
 
-This site publishes OAuth Protected Resource Metadata and Authorization Server metadata for agent discovery. Live **agent registration that issues privileged credentials is not open** — community content is already public under the `public:read` scope.
+Discover registration metadata, then call the advertised endpoints. Live privileged account creation is not open — the endpoints below document the anonymous discovery contract and return `public_no_auth_required` / `not_applicable` for this static site.
 
-### What needs no registration
+### Audience
 
-Agents may freely:
-
-- Fetch `/.well-known/api-catalog`, `/llms.txt`, `/llms-full.txt`, and `robots.txt`
-- Read Markdown twin endpoints (`Accept: text/markdown` or `*.md` URLs)
-- Call public JSON indexes under `/api/` (posts, series, search)
-- Use in-browser WebMCP tools registered via `navigator.modelContext.registerTool()`
+AI agents and tools that need to discover how (or whether) to register before reading Pereira Tech Talks content.
 
 ### Discovery
 
@@ -23,30 +18,49 @@ Agents may freely:
 GET /.well-known/oauth-protected-resource
 ```
 
-Expect `resource` to match this origin, `authorization_servers` listing this origin, `scopes_supported: ["public:read"]`, and `bearer_methods_supported: ["header"]`.
+Required fields: `resource` (this origin), `authorization_servers`, `scopes_supported` (`public:read`), `bearer_methods_supported` (`header`).
 
-2. Fetch Authorization Server metadata:
+2. Fetch Authorization Server metadata from `authorization_servers[0]`:
 
 ```http
 GET /.well-known/oauth-authorization-server
 ```
 
-Read the `agent_auth` block. `agent_auth.skill` points at this file. `agent_auth.register_uri` is `POST|GET /agent/register` and documents that public content needs no credentials.
+Read the `agent_auth` block. It includes:
 
-### Supported identity type (discovery only)
+- `skill` — this file
+- `register_uri` / `identity_endpoint` — `POST|GET /agent/register`
+- `claim_uri` / `claim_endpoint` — `POST|GET /agent/claim`
+- `claim_complete_uri` — `POST|GET /agent/claim/complete`
+- `revocation_uri` — `POST /oauth/revoke`
+- `identity_types_supported` — includes `anonymous`
+- `anonymous.credential_types_supported` — `access_token`
 
-- **anonymous** — advertised for agent-readiness scanners. Calling `/agent/register` returns `public_no_auth_required` and does **not** create accounts or mint privileged tokens.
+### Supported method: anonymous
+
+1. **Register** — `POST /agent/register` with `{ "type": "anonymous" }`.
+2. **Response** — JSON with `status: "public_no_auth_required"`. No account is created; public Markdown/JSON endpoints need no bearer token.
+3. **Claim (optional discovery only)** — `POST /agent/claim` and `POST /agent/claim/complete` return `not_applicable`. There is no OTP ceremony for `public:read`.
+4. **Credentials** — do not invent client secrets. For public reads, call `/llms.txt`, `/.well-known/api-catalog`, `/api/*`, and Markdown twin URLs without `Authorization`.
+5. **Revocation** — `revocation_uri` is reserved; there are no issued privileged tokens to revoke today.
+
+### What needs no registration
+
+- `/.well-known/api-catalog`, `/llms.txt`, `/llms-full.txt`, `robots.txt`
+- Markdown twin endpoints (`Accept: text/markdown` or `*.md` URLs)
+- Public JSON indexes under `/api/`
+- In-browser WebMCP tools via `navigator.modelContext.registerTool()`
 
 ### Privileged / human workflows
 
-For write access (event forms, sponsorship, speaking):
+Write access (forms, sponsorship, speaking) stays human-mediated:
 
-- Contact form: `/contact/`
+- Contact: `/contact/`
 - Call for speakers: `/call-for-speakers/`
 - Sponsor us: `/sponsor-us/`
 - Email: `hello@pereiratechtalks.org`
 
-Do **not** invent OAuth client credentials, scrape private admin routes, or ask humans to paste API secrets into chat.
+Do not ask humans to paste API secrets into chat.
 
 ## Product links
 
@@ -54,7 +68,7 @@ Do **not** invent OAuth client credentials, scrape private admin routes, or ask 
 - Meetups: `/meetups/`
 - Pereira Tech Days: `/pereira-tech-days/`
 - Blog: `/blog/`
-- Agent skills index: `/.well-known/agent-skills/index.json`
+- Agent skills: `/.well-known/agent-skills/index.json`
 - MCP server card: `/.well-known/mcp/server-card.json`
 
 ## Legal

--- a/tests/unit/functions/oauth-metadata.test.ts
+++ b/tests/unit/functions/oauth-metadata.test.ts
@@ -39,14 +39,28 @@ describe('oauth metadata helpers', () => {
   });
 
   describe('buildOAuthAuthorizationServerMetadata', () => {
-    it('includes agent_auth with register_uri and anonymous method', () => {
+    it('includes top-level claim_uri for anonymous authMd scanners', () => {
       const origin = 'https://v3.pereiratechtalks.org';
       const meta = buildOAuthAuthorizationServerMetadata(origin);
       expect(meta.issuer).toBe(origin);
       expect(meta.agent_auth.skill).toBe(`${origin}/auth.md`);
       expect(meta.agent_auth.register_uri).toBe(`${origin}/agent/register`);
+      expect(meta.agent_auth.identity_endpoint).toBe(
+        `${origin}/agent/register`
+      );
+      // isitagentready fails with "anonymous registration requires claim_uri"
+      // unless claim_uri is present at the agent_auth root (not only nested).
+      expect(meta.agent_auth.claim_uri).toBe(`${origin}/agent/claim`);
+      expect(meta.agent_auth.claim_endpoint).toBe(`${origin}/agent/claim`);
+      expect(meta.agent_auth.claim_complete_uri).toBe(
+        `${origin}/agent/claim/complete`
+      );
       expect(meta.agent_auth.identity_types_supported).toContain('anonymous');
+      expect(meta.agent_auth.anonymous.credential_types_supported).toContain(
+        'access_token'
+      );
       expect(meta.agent_auth.anonymous.claim_uri).toBe(`${origin}/agent/claim`);
+      expect(meta.agent_auth.revocation_uri).toBe(`${origin}/oauth/revoke`);
       expect(meta.bearer_methods_supported).toContain('header');
     });
   });


### PR DESCRIPTION
## Summary
- isitagentready.com scores **93** with one remaining fail: `auth.md exists but agent_auth metadata was not found`.
- Scanner evidence: `anonymous registration requires claim_uri` — it expects **top-level** `agent_auth.claim_uri`, not only `agent_auth.anonymous.claim_uri`.

## Changes
- `agent_auth.claim_uri` / `claim_endpoint` / `claim_complete_uri` / `identity_endpoint` at the root of the AS metadata block
- Keep nested `anonymous.credential_types_supported` + `anonymous.claim_uri` for skill parity
- Stub `GET|POST /agent/claim/complete`
- Allow `HEAD` on OAuth well-known Functions
- Expand `/auth.md` with an explicit anonymous discovery flow
- Unit test asserts top-level `claim_uri`

## Test plan
- [x] `pnpm run test` (oauth-metadata)
- [ ] After deploy: `curl -s https://v3.pereiratechtalks.org/.well-known/oauth-authorization-server | jq .agent_auth.claim_uri`
- [ ] Re-scan https://isitagentready.com/v3.pereiratechtalks.org — `discovery.authMd` → pass (target **100**)


Made with [Cursor](https://cursor.com)