### PR TITLE
fix(i18n): drop forced browser language redirect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,7 @@ import AboutUsPage from '@/components/pages/AboutUsPage.astro';
 
 ### 5. i18n Routing
 
-Spanish pages at root (`src/pages/` → `/`), English in `src/pages/en/` (→ `/en`). First-time visitors are redirected to their browser's language **from the home page only**; an explicit choice is stored in `localStorage['ptt:lang']` and wins on later visits — see [I18N Guide → Browser-Language Detection](docs/I18N_GUIDE.md#browser-language-detection). Any new language switcher MUST persist the choice or the next visit reverts to the browser. Page components in `src/components/pages/` receive `lang` and handle translations internally. Spanish is the **primary language** of the community and therefore the unprefixed default; English is first-class international. Never hardcode a `/en` or `/es` prefix — derive it from `getUrlPrefix(lang)`.
+Spanish pages at root (`src/pages/` → `/`), English in `src/pages/en/` (→ `/en`). Language is **URL-first**: there is no automatic redirect from browser language or `localStorage` — see [I18N Guide → Language selection](docs/I18N_GUIDE.md#language-selection-url-first). The switcher may still write `localStorage['ptt:lang']` as a soft preference; only `?lang=` may pin/redirect. Page components in `src/components/pages/` receive `lang` and handle translations internally. Spanish is the **primary language** of the community and therefore the unprefixed default; English is first-class international. Never hardcode a `/en` or `/es` prefix — derive it from `getUrlPrefix(lang)`.
 
 ### 6. Per-Edition Theming Runtime
 

--- a/docs/I18N_GUIDE.md
+++ b/docs/I18N_GUIDE.md
@@ -419,49 +419,38 @@ The header includes a language switcher that toggles between English and Spanish
 - `/blog/` ↔ `/en/blog/`
 - `/blog/tag/tech/` ↔ `/en/blog/tag/tech/`
 
-## Browser-Language Detection
+## Language selection (URL-first)
 
-First-time visitors land on the language their browser asks for; returning
-visitors get whatever they last chose. Implemented by
+Language is determined by the URL, the same model as xergioalex.com:
+
+| Language | Home |
+|----------|------|
+| Spanish (primary) | `/` |
+| English | `/en/` |
+
+There is **no** automatic client-side redirect based on `navigator.languages`
+or `localStorage`. Visitors stay on the URL they opened; they change language
+only via the header/mobile switcher (or an explicit `?lang=es|en` pin).
+
 [`src/components/LanguageRedirect.astro`](../src/components/LanguageRedirect.astro)
-(a blocking inline script in `<head>`, so there is no flash of the wrong
-language) over the pure, unit-tested rules in
+only handles `?lang=` (used by LHCI: `/?lang=es`). Pure helpers live in
 [`src/lib/language-preference.ts`](../src/lib/language-preference.ts).
 
-**Decision order**
+**Why no browser auto-redirect**
 
-1. **`?lang=es|en`** — an explicit override. Wins over everything and is stored.
-2. **Stored preference** (`localStorage['ptt:lang']`) — set whenever the visitor
-   uses the language switcher, and also written on the first visit. Beats the
-   browser, so an explicit choice is never second-guessed.
-3. **Browser language** — `navigator.languages`, matched on the primary subtag
-   (`es-CO`, `es-419` and `es` all resolve to `es`). Falls back to the site
-   default (`es`) when nothing matches.
+- PageSpeed Insights flagged a "Clientside Redirect!" when English browsers
+  hit `/` and were sent to `/en/`.
+- Shared deep links must keep the language they were shared in (hreflang
+  stays truthful).
+- Spanish is the community primary — first paint on `/` should stay Spanish.
 
-**Deliberate limits**
+**Optional persistence.** `Header.svelte` and `MobileMenu.svelte` still call
+`rememberLanguage()` into `localStorage['ptt:lang']` when the visitor uses
+the switcher. That value is soft preference only; it does **not** force a
+redirect on later visits.
 
-- **Only the home page negotiates.** Deep links are never rewritten: a Spanish
-  article shared with an English-browser reader keeps its language. This also
-  keeps both language trees independently crawlable, so hreflang stays truthful
-  — auto-redirecting every URL is a classic way to get one language deindexed.
-- **Cannot loop.** A redirect is only issued when the target differs from the
-  page being served; after it, the stored preference matches and the next
-  evaluation is a no-op.
-- **Never fatal.** All storage access is wrapped — private mode or disabled
-  storage degrades to plain browser detection, and any error leaves the page as
-  served.
-- **Audit tools are skipped.** Lighthouse / PageSpeed / Chrome-Lighthouse /
-  HeadlessChrome user agents, and any browser with `navigator.webdriver`, do
-  not negotiate language. A client-side redirect would trigger PSI's
-  "Clientside Redirect!" modal and pollute LHCI lab metrics; those tools should
-  score the URL they were given. LHCI additionally pins the Spanish home with
-  `/?lang=es` and `--lang=es-ES` because Chrome's new headless often exposes
-  neither `webdriver` nor `HeadlessChrome` in the UA.
-
-**Changing the language must persist.** Both `Header.svelte` and
-`MobileMenu.svelte` call `rememberLanguage()` on switch. A new language entry
-point MUST do the same, or the next visit will silently revert to the browser's
-language.
+**Lab tooling.** Prefer `/?lang=es` (and LHCI `--lang=es-ES`) when auditing
+the Spanish home so the language is pinned without relying on UA sniffing.
 
 ## Bilingual Compliance Checklist
 

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -5,16 +5,13 @@ module.exports = {
       // Keep CI lean: home + flagship conference listing only.
       // Full surface lives in lighthouserc.full.cjs (`pnpm run lighthouse:full`).
       //
-      // `?lang=es` pins the Spanish home without a client redirect. LHCI's
-      // Chrome (new headless) neither sets navigator.webdriver nor puts
-      // HeadlessChrome/Lighthouse in the UA, so LanguageRedirect would
-      // otherwise send `/` → `/en/` and tank Performance.
+      // `?lang=es` still pins Spanish explicitly (optional now that there is
+      // no browser-language auto-redirect). Kept for stable LHCI baselines.
       url: ['/?lang=es', '/pereira-tech-days/'],
       // Median of 3 reduces LHCI noise around the 0.99↔1.00 boundary.
       numberOfRuns: 3,
       settings: {
-        // --lang=es-ES: browser languages match Spanish primary (belt + suspenders).
-        // Lighthouse in UA: same skip path PageSpeed uses if negotiation runs.
+        // --lang=es-ES + Lighthouse UA: leftover skip path in LanguageRedirect.
         chromeFlags:
           '--no-sandbox --headless --lang=es-ES --user-agent="Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36 Chrome-Lighthouse"',
         // Skip the robots-txt audit because it follows RFC 9309 strictly and

--- a/src/components/LanguageRedirect.astro
+++ b/src/components/LanguageRedirect.astro
@@ -1,24 +1,16 @@
 ---
 /**
- * First-visit browser-language negotiation.
+ * Optional explicit `?lang=` pin — no automatic language negotiation.
  *
- * Renders a tiny blocking script in `<head>` so the decision happens before
- * first paint — a deferred script would flash the wrong language first.
+ * Language is URL-first (Spanish at `/`, English at `/en/`), matching
+ * xergioalex.com. Browser detection and localStorage never force a redirect
+ * (that triggered PageSpeed's "Clientside Redirect!" modal).
  *
- * The rules live in `src/lib/language-preference.ts` (pure and unit-tested);
- * they are inlined here because this must run before any module loads. Keep
- * the two in sync — the tests are the contract.
+ * The only redirect this script may issue is when the visitor (or LHCI)
+ * passes `?lang=es|en` and the current page language differs. Lab UAs are
+ * still skipped as belt-and-suspenders when combined with other tooling.
  *
- * Deliberate constraints:
- *   - Only the home page negotiates. Deep links are never rewritten, so a
- *     shared article keeps the language it was shared in, and both language
- *     trees stay independently crawlable (hreflang stays truthful).
- *   - An explicit choice (language switcher, or `?lang=`) is persisted and
- *     always beats the browser on later visits.
- *   - Cannot loop: it only navigates when the target differs from the page
- *     being served, and the target page then matches the stored preference.
- *   - Lab / automation tools are skipped (Lighthouse UA, HeadlessChrome,
- *     navigator.webdriver) so lab audits do not hit a client-side redirect.
+ * Pure rules: `src/lib/language-preference.ts` (unit-tested). Keep in sync.
  */
 
 import {
@@ -40,7 +32,6 @@ interface Props {
 const { lang } = Astro.props;
 const currentLang = isValidLanguage(lang) ? lang : DEFAULT_LANGUAGE;
 
-// Serialize the registry so the inline script needs no imports.
 const homeUrls: Record<string, string> = {};
 for (const l of getSupportedLanguages()) {
   const prefix = getUrlPrefix(l);
@@ -51,7 +42,6 @@ const config = JSON.stringify({
   current: currentLang,
   homeUrls,
   supported: getSupportedLanguages(),
-  fallback: DEFAULT_LANGUAGE,
   storageKey: LANGUAGE_STORAGE_KEY,
   queryParam: LANGUAGE_QUERY_PARAM,
 });
@@ -63,9 +53,6 @@ const config = JSON.stringify({
       const c = JSON.parse(config);
       const isSupported = (v) => typeof v === 'string' && c.supported.includes(v);
 
-      // Skip for lab / automation tools. A client-side redirect triggers PSI's
-      // "Clientside Redirect!" modal and burns ~600ms in LHCI (HeadlessChrome
-      // does not include "Lighthouse" in its UA). Real users still negotiate.
       const ua = navigator.userAgent || '';
       if (
         navigator.webdriver ||
@@ -76,62 +63,19 @@ const config = JSON.stringify({
 
       const params = new URLSearchParams(window.location.search);
       const forced = params.get(c.queryParam);
+      if (!isSupported(forced)) return;
 
-      let stored = null;
       try {
-        stored = window.localStorage.getItem(c.storageKey);
+        window.localStorage.setItem(c.storageKey, forced);
       } catch {
-        // Private mode / storage disabled — fall through to browser detection.
+        /* non-fatal */
       }
 
-      const persist = (value) => {
-        try {
-          window.localStorage.setItem(c.storageKey, value);
-        } catch {
-          /* non-fatal */
-        }
-      };
-
-      // `?lang=` wins and is remembered.
-      if (isSupported(forced)) {
-        persist(forced);
-        if (forced !== c.current) {
-          window.location.replace(c.homeUrls[forced]);
-        }
-        return;
+      if (forced !== c.current) {
+        window.location.replace(c.homeUrls[forced]);
       }
-
-      // Only the home page negotiates; deep links are left alone.
-      const path = window.location.pathname.replace(/(.)\/$/, '$1');
-      const isHome =
-        path === '' ||
-        path === '/' ||
-        c.supported.some((l) => c.homeUrls[l].replace(/(.)\/$/, '$1') === path);
-      if (!isHome) return;
-
-      // Later visits: an explicit choice beats the browser.
-      if (isSupported(stored)) {
-        if (stored !== c.current) window.location.replace(c.homeUrls[stored]);
-        return;
-      }
-
-      // First visit: match the browser, then remember it.
-      const candidates = navigator.languages?.length
-        ? navigator.languages
-        : [navigator.language || ''];
-      let detected = c.fallback;
-      for (const raw of candidates) {
-        const primary = String(raw).toLowerCase().split('-')[0];
-        if (c.supported.includes(primary)) {
-          detected = primary;
-          break;
-        }
-      }
-
-      persist(detected);
-      if (detected !== c.current) window.location.replace(c.homeUrls[detected]);
     } catch {
-      // Never let language negotiation break the page.
+      // Never let language handling break the page.
     }
   })();
 </script>

--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -41,10 +41,7 @@ onMount(() => {
   });
 });
 
-/**
- * Persist an explicit language choice so the first-visit browser detection in
- * `LanguageRedirect.astro` never overrides it on a later visit.
- */
+/** Soft preference only — does not force redirects (URL is source of truth). */
 function rememberLanguage(target: string) {
   try {
     window.localStorage.setItem(LANGUAGE_STORAGE_KEY, target);

--- a/src/components/layout/MobileMenu.svelte
+++ b/src/components/layout/MobileMenu.svelte
@@ -22,10 +22,7 @@ let menuRoot: HTMLElement | undefined;
 let closeButtonRef: HTMLButtonElement | undefined;
 let previouslyFocused: HTMLElement | null = null;
 
-/**
- * Persist an explicit language choice so the first-visit browser detection in
- * `LanguageRedirect.astro` never overrides it on a later visit.
- */
+/** Soft preference only — does not force redirects (URL is source of truth). */
 function rememberLanguage(target: string) {
   try {
     window.localStorage.setItem(LANGUAGE_STORAGE_KEY, target);

--- a/src/lib/language-preference.ts
+++ b/src/lib/language-preference.ts
@@ -1,21 +1,16 @@
 /**
- * Browser-language detection with a persisted preference.
+ * Language preference helpers.
  *
- * Behaviour:
- *   1. First visit  — no stored preference: pick the best match for the
- *      browser's languages, persist it, and redirect if it differs from the
- *      page being served.
- *   2. Later visits — a stored preference exists: honour it and ignore the
- *      browser entirely, so an explicit choice always wins.
+ * PTT follows the same model as xergioalex.com: the URL is the source of
+ * truth for language. There is **no** automatic client-side redirect based
+ * on `navigator.languages` or a stored preference — that caused PageSpeed's
+ * "Clientside Redirect!" modal and hijacked first visits away from Spanish
+ * (the community primary).
  *
- * Scope is deliberately limited to the **home page**. Redirecting deep links
- * would hijack shared URLs — someone sending a Spanish article to a friend
- * with an English browser should not have their link silently swapped. Both
- * language versions therefore stay independently reachable and indexable,
- * which is also what keeps hreflang honest.
- *
- * The logic below is pure so it can be unit-tested without a DOM; the thin
- * browser wiring lives in `LanguageRedirect.astro`.
+ * The only navigation this module may request is an explicit `?lang=es|en`
+ * override (used by LHCI / shared links that want to pin a language). The
+ * header language switcher still writes `localStorage['ptt:lang']` for soft
+ * preference tracking, but that value never forces a redirect.
  */
 
 import {
@@ -26,7 +21,7 @@ import {
   type Language,
 } from '@/lib/i18n';
 
-/** localStorage key holding the visitor's explicit or first-visit language. */
+/** localStorage key holding the visitor's last explicit language switch. */
 export const LANGUAGE_STORAGE_KEY = 'ptt:lang';
 
 /** Query parameter that forces a language and persists it (e.g. `?lang=en`). */
@@ -37,6 +32,8 @@ export const LANGUAGE_QUERY_PARAM = 'lang';
  *
  * Matches on the primary subtag, so `es-CO`, `es-419` and `es` all resolve to
  * `es`. Returns the site default when nothing matches.
+ *
+ * Kept for optional UI hints; it does **not** drive redirects.
  */
 export function matchBrowserLanguage(
   browserLanguages: readonly string[] | undefined
@@ -74,9 +71,9 @@ export interface ResolveOptions {
   currentLang: Language;
   /** `window.location.pathname`. */
   pathname: string;
-  /** Value read from localStorage, if any. */
+  /** Value read from localStorage, if any (ignored for redirects). */
   stored?: string | null;
-  /** `navigator.languages` (or `[navigator.language]`). */
+  /** `navigator.languages` (ignored for redirects). */
   browserLanguages?: readonly string[];
   /** Value of the `?lang=` query parameter, if present. */
   forced?: string | null;
@@ -92,16 +89,15 @@ export interface LanguageDecision {
 }
 
 /**
- * Decide which language the visitor should see and whether to navigate.
+ * Decide whether to navigate for language.
  *
- * Never returns a redirect to the page already being served, so it cannot
- * loop: after a redirect the target page's `currentLang` equals the stored
- * preference and the next evaluation is a no-op.
+ * Only an explicit `?lang=` may redirect. Browser detection and stored
+ * preference never rewrite the URL — same URL-first model as xergioalex.com.
  */
 export function resolveLanguageDecision(
   options: ResolveOptions
 ): LanguageDecision {
-  const { currentLang, pathname, stored, browserLanguages, forced } = options;
+  const { currentLang, forced } = options;
 
   // An explicit `?lang=` always wins and is remembered.
   if (forced && isValidLanguage(forced)) {
@@ -112,25 +108,6 @@ export function resolveLanguageDecision(
     };
   }
 
-  // Deep links are never rewritten — only the home page negotiates language.
-  if (!isHomePath(pathname)) {
-    return { lang: currentLang, redirectTo: null, persist: false };
-  }
-
-  // Later visits: the stored choice wins outright.
-  if (stored && isValidLanguage(stored)) {
-    return {
-      lang: stored,
-      redirectTo: stored === currentLang ? null : homeUrlFor(stored),
-      persist: false,
-    };
-  }
-
-  // First visit: fall back to the browser, and remember the result.
-  const detected = matchBrowserLanguage(browserLanguages);
-  return {
-    lang: detected,
-    redirectTo: detected === currentLang ? null : homeUrlFor(detected),
-    persist: true,
-  };
+  // URL wins — no auto-negotiation from browser or localStorage.
+  return { lang: currentLang, redirectTo: null, persist: false };
 }

--- a/tests/unit/lib/language-preference.test.ts
+++ b/tests/unit/lib/language-preference.test.ts
@@ -76,74 +76,34 @@ describe('homeUrlFor', () => {
 // ─── resolveLanguageDecision ───────────────────────────
 
 describe('resolveLanguageDecision', () => {
-  it('redirects a first-time English browser from the Spanish root', () => {
+  it('does not redirect a first-time English browser away from Spanish root', () => {
     const d = resolveLanguageDecision({
       currentLang: 'es',
       pathname: '/',
-      stored: null,
-      browserLanguages: ['en-US'],
-    });
-    expect(d).toEqual({ lang: 'en', redirectTo: '/en/', persist: true });
-  });
-
-  it('stays put — and still persists — when the browser already matches', () => {
-    const d = resolveLanguageDecision({
-      currentLang: 'es',
-      pathname: '/',
-      stored: null,
-      browserLanguages: ['es-CO'],
-    });
-    expect(d).toEqual({ lang: 'es', redirectTo: null, persist: true });
-  });
-
-  it('lets a stored preference beat the browser on later visits', () => {
-    const d = resolveLanguageDecision({
-      currentLang: 'es',
-      pathname: '/',
-      stored: 'en',
-      browserLanguages: ['es-CO'],
-    });
-    expect(d).toEqual({ lang: 'en', redirectTo: '/en/', persist: false });
-  });
-
-  it('does not re-persist or redirect when the stored preference is already served', () => {
-    const d = resolveLanguageDecision({
-      currentLang: 'en',
-      pathname: '/en/',
-      stored: 'en',
-      browserLanguages: ['es-CO'],
-    });
-    expect(d).toEqual({ lang: 'en', redirectTo: null, persist: false });
-  });
-
-  it('ignores a corrupt stored value and falls back to the browser', () => {
-    const d = resolveLanguageDecision({
-      currentLang: 'es',
-      pathname: '/',
-      stored: 'klingon',
-      browserLanguages: ['en'],
-    });
-    expect(d).toEqual({ lang: 'en', redirectTo: '/en/', persist: true });
-  });
-
-  it('never rewrites a deep link, even when the browser disagrees', () => {
-    const d = resolveLanguageDecision({
-      currentLang: 'es',
-      pathname: '/blog/some-post/',
       stored: null,
       browserLanguages: ['en-US'],
     });
     expect(d).toEqual({ lang: 'es', redirectTo: null, persist: false });
   });
 
-  it('never rewrites a deep link even with a conflicting stored preference', () => {
+  it('does not redirect when a stored preference disagrees with the URL', () => {
     const d = resolveLanguageDecision({
       currentLang: 'es',
-      pathname: '/about',
+      pathname: '/',
       stored: 'en',
-      browserLanguages: ['en'],
+      browserLanguages: ['es-CO'],
     });
-    expect(d.redirectTo).toBeNull();
+    expect(d).toEqual({ lang: 'es', redirectTo: null, persist: false });
+  });
+
+  it('never rewrites a deep link', () => {
+    const d = resolveLanguageDecision({
+      currentLang: 'es',
+      pathname: '/blog/some-post/',
+      stored: 'en',
+      browserLanguages: ['en-US'],
+    });
+    expect(d).toEqual({ lang: 'es', redirectTo: null, persist: false });
   });
 
   it('honours an explicit ?lang= override and remembers it', () => {
@@ -164,6 +124,7 @@ describe('resolveLanguageDecision', () => {
       forced: 'en',
     });
     expect(d.lang).toBe('en');
+    expect(d.redirectTo).toBe('/en/');
     expect(d.persist).toBe(true);
   });
 
@@ -172,23 +133,18 @@ describe('resolveLanguageDecision', () => {
       currentLang: 'es',
       pathname: '/',
       stored: null,
-      browserLanguages: ['es'],
+      browserLanguages: ['en'],
       forced: 'zz',
     });
-    expect(d.lang).toBe('es');
-    expect(d.redirectTo).toBeNull();
+    expect(d).toEqual({ lang: 'es', redirectTo: null, persist: false });
   });
 
-  it('cannot loop: the redirect target never equals the page being served', () => {
-    for (const current of ['es', 'en'] as const) {
-      for (const stored of ['es', 'en'] as const) {
-        const d = resolveLanguageDecision({
-          currentLang: current,
-          pathname: current === 'es' ? '/' : '/en/',
-          stored,
-        });
-        if (d.redirectTo !== null) expect(d.lang).not.toBe(current);
-      }
-    }
+  it('stays put when ?lang= matches the page already being served', () => {
+    const d = resolveLanguageDecision({
+      currentLang: 'es',
+      pathname: '/',
+      forced: 'es',
+    });
+    expect(d).toEqual({ lang: 'es', redirectTo: null, persist: true });
   });
 });


### PR DESCRIPTION
## Summary
- Remove automatic client-side language negotiation (browser `navigator.languages` + `localStorage['ptt:lang']`) that forced `/` → `/en/` for English browsers.
- Align with URL-first i18n (same model as xergioalex.com): Spanish stays at `/`, English at `/en/`; visitors change language only via the switcher.
- Keep optional `?lang=es|en` pin (used by LHCI) and soft `localStorage` write on switch — neither forces later visits.

## Why
The previous home-page redirect triggered PageSpeed Insights’ “Clientside Redirect!” modal and pulled first-time English visitors off the Spanish primary home.

## Test plan
- [ ] Open `/` with an English browser language — stays on Spanish home (no redirect)
- [ ] Open `/en/` — stays English
- [ ] Language switcher still navigates between ES ↔ EN
- [ ] `/?lang=en` still redirects to `/en/` and persists preference
- [ ] `pnpm exec vitest run tests/unit/lib/language-preference.test.ts` passes
- [ ] PageSpeed on `/` no longer shows Clientside Redirect modal


Made with [Cursor](https://cursor.com)