### PR TITLE
feat(ptd): redesign Pereira Tech Days hub for two-edition world

### DIFF
--- a/docs/INFORMATION_ARCHITECTURE.md
+++ b/docs/INFORMATION_ARCHITECTURE.md
@@ -42,7 +42,7 @@ match this IA, you are creating drift.
 | Meetup detail | `/meetups/{slug}` | `/en/meetups/{slug}` | `meetups` | `meetups/[slug].astro` | `MeetupDetailPage.astro` | per-slug `.md` |
 | Events calendar | `/events` | `/es/events` | `events` + `meetups` | `events/index.astro` | `EventsCalendarPage.astro` | yes |
 | Event detail | `/events/{slug}` | `/es/events/{slug}` | `events` | `events/[slug].astro` | `EventDetailPage.astro` | per-slug `.md` |
-| PTT Days umbrella | `/pereira-tech-days` | `/es/pereira-tech-days` | `pereiraTechDays` | `pereira-tech-days/index.astro` | `PereiraTechDaysListPage.astro` | yes |
+| PTT Days umbrella | `/pereira-tech-days` | `/en/pereira-tech-days` | `pereiraTechDays` | `pereira-tech-days/index.astro` | `PereiraTechDaysPage.astro` | yes |
 | PTT Day edition | `/pereira-tech-days/{year}` | `/es/pereira-tech-days/{year}` | `pereiraTechDays` | `pereira-tech-days/[year].astro` | `PereiraTechDayEditionPage.astro` (wraps in `EditionScope`) | per-year `.md` |
 | Speakers catalog | `/speakers` | `/es/speakers` | `speakers` | `speakers/index.astro` | `SpeakersCatalogPage.astro` | yes |
 | Speaker profile | `/speakers/{slug}` | `/es/speakers/{slug}` | `speakers` | `speakers/[slug].astro` | `SpeakerProfilePage.astro` | per-slug `.md` |

--- a/docs/features/PEREIRA_TECH_DAYS.md
+++ b/docs/features/PEREIRA_TECH_DAYS.md
@@ -13,7 +13,7 @@ The **Pereira Tech Day** (PTD) collection powers the annual flagship conference'
 
 | Route (ES, root) | Route (EN, `/en`) | Purpose |
 |---|---|---|
-| `/pereira-tech-days` | `/en/pereira-tech-days` | Edition directory (all years, newest first) |
+| `/pereira-tech-days` | `/en/pereira-tech-days` | Hub — featured upcoming edition + past edition rows |
 | `/pereira-tech-days/{year}` | `/en/pereira-tech-days/{year}` | Edition detail — upcoming or past template |
 | `/pereira-tech-days/{year}/certificates/{id}` | `/en/pereira-tech-days/{year}/certificates/{id}` | Individual attendance certificate (see [Certificates](CERTIFICATES.md)) |
 | `/pereira-tech-days/{year}.md` (via `[year].md.ts`) | `/en/pereira-tech-days/{year}.md` | Markdown-for-Agents endpoint mirroring the detail page |
@@ -143,6 +143,50 @@ ui: z.object({
 - `typography.fontSources[].npmPackage` drives `getEditionFontPackages(edition)`, which returns the de-duplicated list of npm font packages an edition declares. The detail page only renders `<PtdEditionFonts packages={fontPackages} />` when that list is non-empty, so editions without a custom heading font never pay the webfont cost. `PtdEditionFonts.astro` statically imports `@fontsource/bebas-neue` (currently the only supported package) behind a `SUPPORTED_PACKAGES` allow-list.
 - `ui.buttonShape` / `ui.cardShape` map to `--ptd-button-radius` / `--ptd-card-radius` via `BUTTON_RADIUS_BY_SHAPE` / `CARD_RADIUS_BY_SHAPE` in `buildEditionThemeCss()` (`src/lib/pereiraTechDay.ts`), defaulting to the "rounded" mapping when `ui` is undeclared. Components consume these as `rounded-[var(--ptd-button-radius,9999px)]` / `rounded-[var(--ptd-card-radius,1rem)]` with a literal fallback, so every edition renders sane radii even without an explicit `ui` block (2024 has none).
 
+## Hub directory page (`/pereira-tech-days`)
+
+The hub is the **flagship conference series homepage** — not a generic edition catalog. It has its own dedicated page component (`src/components/pages/PereiraTechDaysPage.astro`) and its own set of hub-only components. It uses **global PTT chrome only** — no `EditionScope` wrapper, no `data-edition-theme` attribute anywhere on this route.
+
+### Composition order
+
+| Zone | Component | Notes |
+|---|---|---|
+| 1st viewport | `PtdHubFeaturedStage.astro` | Full-bleed dark stage for the upcoming edition; empty-state fallback when no upcoming edition exists |
+| Mid page | `PtdHubPastRow.astro` (one per past edition) | Horizontal band (image ≈45% + copy/CTA); single row, never a card grid |
+| Close | Join strip (`Section` primitive) | Slim community CTA via `t.joinTitle` / `t.joinSubtitle` / `t.joinCta` |
+
+### `PtdHubFeaturedStage` — upcoming edition cinematic stage
+
+- Renders when `getUpcomingEdition()` returns a result (`status: 'announced' | 'rsvp-open'`).
+- Atmospheric hero image: `opacity-30` + dual gradient overlays (left-dark + top-bottom-dark). No `EditionScope` — uses PTT global tokens throughout.
+- Includes a live countdown via `PtdCountdown.svelte` with `variant="hub"` (white/white-10 tokens for WCAG AA on the dark stage background; contrast verified ≥4.5:1).
+- Three tiered CTAs: primary (`t.indexStagePrimaryCta` → edition detail), secondary (`t.indexCfsCta` → call for speakers), tertiary (`t.indexSponsorCta` → sponsor-us, text-only).
+- Countdown ISO dates come from `getEditionCountdownTargets(edition)` → `{ targetDate, endDate? }`.
+
+**Empty state** (no upcoming edition): The stage renders a fallback section with `t.indexNoUpcomingTitle` + `t.indexNoUpcomingIntro` + a CTA to the latest past edition + a CFS link.
+
+### `PtdHubPastRow` — past edition horizontal band
+
+- One instance per `editions.filter(e => e.data.status === 'completed' || e.data.status === 'cancelled')` in `PereiraTechDaysPage.astro`.
+- Desktop: flex-row — image `md:w-[45%]` left, copy/CTA right.
+- Mobile: stacks vertically — continuous story, not a card grid.
+- Decorative 1px accent stripe (`h-1`) at the top uses `brandKit.paletteLight.accent` to echo the edition's identity without requiring `EditionScope`.
+- Image hover scale uses `motion-safe:group-hover:scale-[1.02] motion-reduce:transition-none` (reduced-motion compliant).
+- Image link is `tabindex="-1" aria-hidden="true"` (the CTA below is the keyboard-accessible link).
+
+### Hub chrome rule
+
+**No `EditionScope` on the hub.** The hub renders in the global PTT palette — `--ptt-primary`, `--ptt-bg`, `--ptt-text`, `--ptt-accent` are the standard site tokens. This keeps the header, footer, theme toggle, and language switcher in full PTT brand even when the most recent edition has a distinct per-edition palette (e.g., 2026 teal vs. 2024 dark). Edition-specific palettes are only scoped inside `[data-edition-theme]` on detail routes.
+
+### Hub countdown variant
+
+`PtdCountdown.svelte` accepts a `variant: 'edition' | 'hub'` prop (default `'edition'`):
+
+| Variant | Token source | When to use |
+|---|---|---|
+| `'edition'` | Per-edition CSS vars (`--ptt-primary`, `--ptt-bg-elevated`, etc.) | Edition detail hero (`PtdHero2026`, edition chrome) |
+| `'hub'` | Global white/white-10 tokens | Hub featured stage (`PtdHubFeaturedStage`) |
+
 ## Upcoming vs. past templates
 
 `isUpcomingEdition(edition)` (`src/lib/pereiraTechDay.ts`) is the **single source of truth** for which template renders — never branch on the year:
@@ -189,6 +233,15 @@ Do not add a third template variant or branch new sections on `edition.data.year
 
 All components live in `src/components/pereira-tech-days/`.
 
+### Hub-only components
+
+| Component | Type | Used by | Role |
+|---|---|---|---|
+| `PtdHubFeaturedStage.astro` | Astro | Hub page (`PereiraTechDaysPage`) | Full-bleed dark stage for the upcoming edition: atmospheric hero image, edition title/tagline, `PtdCountdown variant="hub"`, and three tiered CTAs. Global PTT tokens only — no `EditionScope`. |
+| `PtdHubPastRow.astro` | Astro | Hub page (`PereiraTechDaysPage`) | Horizontal band per past edition: image (≈45%) + copy/CTA. Desktop side-by-side, mobile stacked. Decorative accent stripe from `brandKit.paletteLight.accent`. Not a card grid. |
+
+### Edition-detail components
+
 | Component | Type | Used by | Role |
 |---|---|---|---|
 | `EditionScope.astro` | Astro | Orchestrator | Scopes `brandKit` CSS vars under `[data-edition-theme]`; chrome stays outside |
@@ -205,14 +258,14 @@ All components live in `src/components/pereira-tech-days/`.
 | `PtdGalleryCarousel.svelte` | Svelte (`client:visible`) | Both | `mode="carousel"` (upcoming, single-frame + thumbnails) or `mode="marquee"` (past, infinite duplicated CSS track, pauses on hover/focus, static grid fallback under `prefers-reduced-motion`) |
 | `PtdFaqs.svelte` | Svelte (`client:visible`) | Both | Accordion FAQ list, optional section background |
 | `PtdJoinSection.astro` | Astro | Upcoming | Closing CTA band; `showCta` defaults `true` but the detail page passes `false` (legacy Join has no button) |
-| `PtdCountdown.svelte` | Svelte (`client:visible`) | `PtdHero2026` | Days/hours/minutes/seconds countdown to `targetDate` |
+| `PtdCountdown.svelte` | Svelte (`client:visible`) | `PtdHero2026` (edition), `PtdHubFeaturedStage` (hub) | Days/hours/minutes/seconds countdown to `targetDate`. `variant="edition"` uses per-edition CSS vars; `variant="hub"` uses white/white-10 PTT tokens. |
 | `PtdSubscribeForm.svelte` | Svelte (`client:visible`) | `PtdHero2026` | Email capture posting to `/api/ptd-subscribe`, honeypot field, analytics event `EVENTS.PTD_SUBSCRIBE` |
 
 Shared, non-PTD-specific components also used on the detail page: `TalkCard` (`src/components/cards/TalkCard.astro`) for the talks directory grid, `JsonLd` (`src/components/JsonLd.astro`) for the `Event` structured data.
 
 ## Related data helpers
 
-`src/lib/pereiraTechDay.ts` — `getEditions()`, `getEditionByYear()`, `getUpcomingEdition()`, `getLatestEdition()`, `buildEditionThemeCss()`, `getEditionStartDate()` / `getEditionEndDate()` / `getEditionStartIso()` / `getEditionEndIso()`, `isUpcomingEdition()`, `getEditionFontPackages()`, `normalizeLightningTalks()`.
+`src/lib/pereiraTechDay.ts` — `getEditions()`, `getEditionByYear()`, `getUpcomingEdition()`, `getLatestEdition()`, `buildEditionThemeCss()`, `getEditionStartDate()` / `getEditionEndDate()` / `getEditionStartIso()` / `getEditionEndIso()`, `getEditionCountdownTargets()` (hub helper: returns `{ targetDate, endDate? }` for countdown props), `isUpcomingEdition()`, `getEditionFontPackages()`, `normalizeLightningTalks()`.
 
 Cross-collection lookups used by the orchestrator: `getSpeakersBySlugs()` (`src/lib/speaker.ts`) for keynotes/lightning speakers, `getEditionSponsors()` (`src/lib/sponsor.ts`) for tiered sponsors, `getContributorsBySlugs()` (`src/lib/contributor.ts`) for organizers/collaborators, `getTalksByEvent('pereiraTechDays', edition.id)` (`src/lib/talk.ts`) for the talks directory.
 

--- a/src/components/pages/PereiraTechDaysPage.astro
+++ b/src/components/pages/PereiraTechDaysPage.astro
@@ -1,14 +1,19 @@
 ---
 /**
- * PTT v3.0.0 Pereira Tech Days catalog — flagship conference hub.
- * Atmospheric hero + featured edition story + archive grid + JSON-LD.
+ * PTT v3.0.0 Pereira Tech Days hub — flagship conference series homepage.
+ *
+ * Layout order (brief):
+ *   1. PtdHubFeaturedStage  — upcoming edition + live countdown (or empty-state)
+ *   2. PtdHubPastRow        — one horizontal band per past edition
+ *   3. Join strip           — slim community CTA
+ *
+ * Global PTT chrome only — no EditionScope on this route.
  */
 
-import EditionCard from '@/components/cards/EditionCard.astro';
 import JsonLd from '@/components/JsonLd.astro';
-import Breadcrumbs from '@/components/ui/Breadcrumbs.astro';
+import PtdHubFeaturedStage from '@/components/pereira-tech-days/PtdHubFeaturedStage.astro';
+import PtdHubPastRow from '@/components/pereira-tech-days/PtdHubPastRow.astro';
 import Eyebrow from '@/components/ui/Eyebrow.astro';
-import LinkArrow from '@/components/ui/LinkArrow.astro';
 import Section from '@/components/ui/Section.astro';
 import MainLayout from '@/layouts/MainLayout.astro';
 import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
@@ -27,16 +32,9 @@ const siteUrl = Astro.site?.href?.replace(/\/$/, '') ?? '';
 
 const editions = await getEditions();
 const featured = await getUpcomingEdition();
-const upcoming = editions.filter(
-  (e) => e.data.status === 'announced' || e.data.status === 'rsvp-open'
-);
 const past = editions.filter(
   (e) => e.data.status === 'completed' || e.data.status === 'cancelled'
 );
-
-const firstYear = Math.min(...editions.map((e) => e.data.year));
-const editionCount = editions.length;
-const yearsRunning = new Date().getFullYear() - firstYear + 1;
 
 const pageTitle = 'Pereira Tech Days';
 const pageDescription =
@@ -48,15 +46,6 @@ const breadcrumbs = [
   { label: lang === 'es' ? 'Inicio' : 'Home', href: `${prefix}/` },
   { label: pageTitle },
 ];
-
-const featuredHref = featured
-  ? `${prefix}/pereira-tech-days/${featured.data.year}/`
-  : `${prefix}/pereira-tech-days/`;
-const featuredCta = featured
-  ? lang === 'es'
-    ? `Ver edición ${featured.data.year}`
-    : `View ${featured.data.year} edition`
-  : t.indexUpcoming;
 
 const listJsonLd = {
   '@context': 'https://schema.org',
@@ -94,172 +83,73 @@ const eventSeriesJsonLd = {
     },
   },
 };
+
+const latestPast = past[0];
+const latestPastHref = latestPast
+  ? `${prefix}/pereira-tech-days/${latestPast.data.year}/`
+  : undefined;
 ---
 
 <MainLayout lang={lang} title={pageTitle} description={pageDescription}>
   <JsonLd data={listJsonLd} />
   <JsonLd data={eventSeriesJsonLd} />
 
-  <!-- Full-bleed dark hero — brand-first, one CTA -->
-  <section
-    class="relative overflow-hidden bg-ptt-bg-dark text-white"
-    aria-label={pageTitle}
-  >
-    <div aria-hidden="true" class="pointer-events-none absolute inset-0">
-      <img
-        src="/images/home/hero-dark-1280.webp"
-        alt=""
-        width={1280}
-        height={512}
-        class="h-full w-full object-cover opacity-40"
-        loading="eager"
-        decoding="async"
-      />
-      <div
-        class="absolute inset-0 bg-gradient-to-r from-ptt-bg-dark via-ptt-bg-dark/85 to-ptt-bg-dark/40"
-      >
-      </div>
-      <div
-        class="absolute inset-0 bg-gradient-to-t from-ptt-bg-dark via-transparent to-ptt-bg-dark/50"
-      >
-      </div>
-    </div>
-
-    <div class="relative main-container pt-10 pb-4 sm:pt-14">
-      <Breadcrumbs items={breadcrumbs} onDark />
-    </div>
-
-    <div class="relative main-container pb-16 pt-6 sm:pb-20 sm:pt-10 lg:pb-24">
-      <Eyebrow variant="accent">{t.indexEyebrow}</Eyebrow>
-      <h1
-        class="mt-3 max-w-4xl text-4xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl"
-      >
-        {pageTitle}
-      </h1>
-      <p class="mt-4 max-w-2xl text-lg leading-relaxed text-white/85">
-        {t.indexIntro}
-      </p>
-      <div class="mt-8 flex flex-wrap gap-3">
-        <a
-          href={featuredHref}
-          class="inline-flex min-h-[44px] items-center rounded-full bg-ptt-accent px-6 py-2.5 text-sm font-semibold text-ptt-bg-dark transition hover:bg-ptt-accent-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-accent"
-        >
-          {featuredCta}
-        </a>
-        <a
-          href={`${prefix}/call-for-speakers/`}
-          class="inline-flex min-h-[44px] items-center rounded-full border border-white/70 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-        >
-          {t.indexCfsCta}
-        </a>
-      </div>
-
-      <dl
-        class="mt-12 grid max-w-3xl grid-cols-3 gap-4 border-t border-white/15 pt-8 sm:gap-8"
-      >
-        <div>
-          <dt class="text-sm font-semibold uppercase tracking-widest text-white/60">
-            {t.indexStatEditions}
-          </dt>
-          <dd class="mt-1 text-3xl font-bold tabular-nums sm:text-4xl">
-            {editionCount}
-          </dd>
-        </div>
-        <div>
-          <dt class="text-sm font-semibold uppercase tracking-widest text-white/60">
-            {t.indexStatYears}
-          </dt>
-          <dd class="mt-1 text-3xl font-bold tabular-nums sm:text-4xl">
-            {yearsRunning}+
-          </dd>
-        </div>
-        <div>
-          <dt class="text-sm font-semibold uppercase tracking-widest text-white/60">
-            {t.indexStatSince}
-          </dt>
-          <dd class="mt-1 text-3xl font-bold tabular-nums sm:text-4xl">
-            {firstYear}
-          </dd>
-        </div>
-      </dl>
-    </div>
-  </section>
-
+  <!-- 1. Featured stage — upcoming edition OR empty state -->
   {
-    featured && (
-      <Section
-        eyebrow={t.indexFeatured}
-        title={tr(featured.data.title, lang)}
-        subtitle={tr(featured.data.tagline, lang)}
-        surface="alt"
+    featured ? (
+      <PtdHubFeaturedStage edition={featured} lang={lang} breadcrumbs={breadcrumbs} />
+    ) : (
+      /* Empty state: no upcoming edition — series intro with CTA to latest past */
+      <section
+        class="relative overflow-hidden bg-ptt-bg-dark text-white"
+        aria-label={pageTitle}
       >
-        <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
-          <div>
-            <p class="text-sm font-semibold uppercase tracking-widest text-ptt-primary dark:text-ptt-primary-dark">
-              {featured.data.year}
-            </p>
-            <p class="mt-4 text-base leading-relaxed text-ptt-secondary">
-              {tr(featured.data.description, lang)}
-            </p>
-            <div class="mt-8 flex flex-wrap items-center gap-4">
+        <div
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-0 bg-gradient-to-br from-ptt-bg-dark via-ptt-primary/10 to-ptt-bg-dark"
+        />
+        <div class="relative main-container pb-16 pt-16 sm:pb-20 sm:pt-20 lg:pb-24">
+          <Eyebrow variant="accent">{t.indexEyebrow}</Eyebrow>
+          <h1 class="mt-3 max-w-4xl text-4xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl">
+            {t.indexNoUpcomingTitle}
+          </h1>
+          <p class="mt-4 max-w-2xl text-lg leading-relaxed text-white/85">
+            {t.indexNoUpcomingIntro}
+          </p>
+          <div class="mt-8 flex flex-wrap gap-3">
+            {latestPastHref && (
               <a
-                href={`${prefix}/pereira-tech-days/${featured.data.year}/`}
+                href={latestPastHref}
                 class="inline-flex min-h-[44px] items-center rounded-full bg-ptt-primary px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-ptt-primary-strong focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark"
               >
-                {featuredCta}
+                {t.indexPastRowCta}
               </a>
-              <LinkArrow href={`${prefix}/sponsor-us/`}>
-                {t.indexSponsorCta}
-              </LinkArrow>
-            </div>
+            )}
+            <a
+              href={`${prefix}/call-for-speakers/`}
+              class="inline-flex min-h-[44px] items-center rounded-full border border-white/50 px-6 py-2.5 text-sm font-semibold text-white/90 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              {t.indexCfsCta}
+            </a>
           </div>
-          <EditionCard edition={featured} lang={lang} loading="eager" />
         </div>
-      </Section>
+      </section>
     )
   }
 
-  {
-    upcoming.length > 1 && (
-      <Section eyebrow={t.indexCalendarEyebrow} title={t.indexUpcoming}>
-        <ul class="grid gap-6 sm:grid-cols-2">
-          {upcoming
-            .filter((e) => e.id !== featured?.id)
-            .map((edition) => (
-              <li>
-                <EditionCard edition={edition} lang={lang} />
-              </li>
-            ))}
-        </ul>
-      </Section>
-    )
-  }
-
+  <!-- 2. Past editions — single horizontal row per edition -->
   {
     past.length > 0 && (
-      <Section
-        eyebrow={t.indexHistoryEyebrow}
-        title={t.indexPast}
-        subtitle={t.indexPastSubtitle}
-        surface="alt"
-      >
-        <ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {past.map((edition) => (
-            <li>
-              <EditionCard edition={edition} lang={lang} />
-            </li>
-          ))}
-        </ul>
-      </Section>
+      <div>
+        {past.map((edition) => (
+          <PtdHubPastRow edition={edition} lang={lang} />
+        ))}
+      </div>
     )
   }
 
-  <Section
-    eyebrow={t.joinTitle}
-    title={t.joinTitle}
-    subtitle={t.joinSubtitle}
-    centered
-  >
+  <!-- 3. Join strip — slim community CTA -->
+  <Section eyebrow={t.joinTitle} title={t.joinTitle} subtitle={t.joinSubtitle} centered>
     <div class="flex flex-wrap justify-center gap-3">
       <a
         href={`${prefix}/`}

--- a/src/components/pereira-tech-days/PtdCountdown.svelte
+++ b/src/components/pereira-tech-days/PtdCountdown.svelte
@@ -5,9 +5,10 @@ interface Props {
   lang: Language;
   targetDate: string;
   endDate?: string;
+  variant?: 'edition' | 'hub';
 }
 
-let { lang, targetDate, endDate }: Props = $props();
+let { lang, targetDate, endDate, variant = 'edition' }: Props = $props();
 
 const labels = {
   en: {
@@ -54,29 +55,60 @@ $effect(() => {
 });
 </script>
 
-<div
-  class="ptd-countdown-block grid grid-cols-4 divide-x divide-[var(--ptt-border)] rounded-[var(--ptd-card-radius,1rem)] bg-[var(--ptt-bg-elevated)] py-3 ring-1 ring-[var(--ptt-border)] sm:py-4"
-  role="timer"
-  aria-live="polite"
-  aria-label={lang === 'es' ? 'Cuenta regresiva' : 'Countdown'}
->
-  {#if ended}
-    <p class="col-span-4 px-4 text-sm font-semibold text-[var(--ptt-primary)]">{t.ended}</p>
-  {:else}
-    {#each [
-      { value: remaining.days, label: t.days },
-      { value: remaining.hours, label: t.hours },
-      { value: remaining.minutes, label: t.minutes },
-      { value: remaining.seconds, label: t.seconds },
-    ] as unit}
-      <div class="px-1 text-center sm:px-2">
-        <span class="block text-2xl font-bold tabular-nums text-[var(--ptt-primary)] sm:text-3xl">
-          {String(unit.value).padStart(2, '0')}
-        </span>
-        <span class="mt-1 block text-[10px] font-semibold uppercase tracking-widest text-[var(--ptt-text-muted)] sm:text-xs">
-          {unit.label}
-        </span>
-      </div>
-    {/each}
-  {/if}
-</div>
+{#if variant === 'hub'}
+  <!-- Hub variant: PTT global tokens, works on dark stage background -->
+  <div
+    class="grid grid-cols-4 divide-x divide-white/20 rounded-2xl bg-white/10 py-3 ring-1 ring-white/20 backdrop-blur-sm sm:py-4"
+    role="timer"
+    aria-live="polite"
+    aria-label={lang === 'es' ? 'Cuenta regresiva' : 'Countdown'}
+  >
+    {#if ended}
+      <p class="col-span-4 px-4 text-sm font-semibold text-white">{t.ended}</p>
+    {:else}
+      {#each [
+        { value: remaining.days, label: t.days },
+        { value: remaining.hours, label: t.hours },
+        { value: remaining.minutes, label: t.minutes },
+        { value: remaining.seconds, label: t.seconds },
+      ] as unit}
+        <div class="px-1 text-center sm:px-2">
+          <span class="block text-2xl font-bold tabular-nums text-white sm:text-3xl">
+            {String(unit.value).padStart(2, '0')}
+          </span>
+          <span class="mt-1 block text-[10px] font-semibold uppercase tracking-widest text-white/70 sm:text-xs">
+            {unit.label}
+          </span>
+        </div>
+      {/each}
+    {/if}
+  </div>
+{:else}
+  <!-- Edition variant: per-edition CSS vars (default) -->
+  <div
+    class="ptd-countdown-block grid grid-cols-4 divide-x divide-[var(--ptt-border)] rounded-[var(--ptd-card-radius,1rem)] bg-[var(--ptt-bg-elevated)] py-3 ring-1 ring-[var(--ptt-border)] sm:py-4"
+    role="timer"
+    aria-live="polite"
+    aria-label={lang === 'es' ? 'Cuenta regresiva' : 'Countdown'}
+  >
+    {#if ended}
+      <p class="col-span-4 px-4 text-sm font-semibold text-[var(--ptt-primary)]">{t.ended}</p>
+    {:else}
+      {#each [
+        { value: remaining.days, label: t.days },
+        { value: remaining.hours, label: t.hours },
+        { value: remaining.minutes, label: t.minutes },
+        { value: remaining.seconds, label: t.seconds },
+      ] as unit}
+        <div class="px-1 text-center sm:px-2">
+          <span class="block text-2xl font-bold tabular-nums text-[var(--ptt-primary)] sm:text-3xl">
+            {String(unit.value).padStart(2, '0')}
+          </span>
+          <span class="mt-1 block text-[10px] font-semibold uppercase tracking-widest text-[var(--ptt-text-muted)] sm:text-xs">
+            {unit.label}
+          </span>
+        </div>
+      {/each}
+    {/if}
+  </div>
+{/if}

--- a/src/components/pereira-tech-days/PtdHubFeaturedStage.astro
+++ b/src/components/pereira-tech-days/PtdHubFeaturedStage.astro
@@ -10,8 +10,7 @@ import Breadcrumbs from '@/components/ui/Breadcrumbs.astro';
 import Eyebrow from '@/components/ui/Eyebrow.astro';
 import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
 import {
-  getEditionEndIso,
-  getEditionStartIso,
+  getEditionCountdownTargets,
   type PereiraTechDay,
 } from '@/lib/pereiraTechDay';
 import { getTranslations } from '@/lib/translations';
@@ -27,8 +26,7 @@ const t = getTranslations(lang).ptdPage;
 const prefix = getUrlPrefix(lang);
 
 const editionHref = `${prefix}/pereira-tech-days/${edition.data.year}/`;
-const targetDate = getEditionStartIso(edition);
-const endDate = getEditionEndIso(edition);
+const { targetDate, endDate } = getEditionCountdownTargets(edition);
 
 const heroSrc = edition.data.hero?.src ?? null;
 const editionTitle = tr(edition.data.title, lang);

--- a/src/components/pereira-tech-days/PtdHubFeaturedStage.astro
+++ b/src/components/pereira-tech-days/PtdHubFeaturedStage.astro
@@ -1,0 +1,138 @@
+---
+/**
+ * Hub featured stage — first viewport for the PTD hub page.
+ * Presents the upcoming edition as a grand, cinematic full-bleed dark stage
+ * with a live countdown. Uses global PTT tokens only — no EditionScope.
+ */
+
+import PtdCountdown from '@/components/pereira-tech-days/PtdCountdown.svelte';
+import Breadcrumbs from '@/components/ui/Breadcrumbs.astro';
+import Eyebrow from '@/components/ui/Eyebrow.astro';
+import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
+import {
+  getEditionEndIso,
+  getEditionStartIso,
+  type PereiraTechDay,
+} from '@/lib/pereiraTechDay';
+import { getTranslations } from '@/lib/translations';
+
+interface Props {
+  edition: PereiraTechDay;
+  lang: Language;
+  breadcrumbs?: { label: string; href?: string }[];
+}
+
+const { edition, lang, breadcrumbs } = Astro.props;
+const t = getTranslations(lang).ptdPage;
+const prefix = getUrlPrefix(lang);
+
+const editionHref = `${prefix}/pereira-tech-days/${edition.data.year}/`;
+const targetDate = getEditionStartIso(edition);
+const endDate = getEditionEndIso(edition);
+
+const heroSrc = edition.data.hero?.src ?? null;
+const editionTitle = tr(edition.data.title, lang);
+const editionTagline = tr(edition.data.tagline, lang);
+---
+
+<section
+  class="relative overflow-hidden bg-ptt-bg-dark text-white"
+  aria-label={editionTitle}
+>
+  <!-- Atmospheric background image -->
+  {
+    heroSrc && (
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-0"
+      >
+        <img
+          src={heroSrc}
+          alt=""
+          width={1280}
+          height={720}
+          class="h-full w-full object-cover opacity-30"
+          loading="eager"
+          decoding="async"
+        />
+        <div class="absolute inset-0 bg-gradient-to-r from-ptt-bg-dark via-ptt-bg-dark/90 to-ptt-bg-dark/60" />
+        <div class="absolute inset-0 bg-gradient-to-t from-ptt-bg-dark via-transparent to-ptt-bg-dark/40" />
+      </div>
+    )
+  }
+  {
+    !heroSrc && (
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-0 bg-gradient-to-br from-ptt-bg-dark via-ptt-primary/10 to-ptt-bg-dark"
+      />
+    )
+  }
+
+  <!-- Breadcrumbs -->
+  {
+    breadcrumbs && breadcrumbs.length > 0 && (
+      <div class="relative main-container pt-10 pb-4 sm:pt-14">
+        <Breadcrumbs items={breadcrumbs} onDark />
+      </div>
+    )
+  }
+
+  <!-- Content -->
+  <div class="relative main-container pb-16 pt-6 sm:pb-20 sm:pt-10 lg:pb-24">
+    <Eyebrow variant="accent">{t.indexEyebrow}</Eyebrow>
+
+    <!-- Edition year badge -->
+    <p class="mt-2 text-sm font-semibold uppercase tracking-widest text-white/60">
+      {edition.data.year}
+    </p>
+
+    <!-- Edition title as primary H1 -->
+    <h1 class="mt-2 max-w-4xl text-4xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl">
+      {editionTitle}
+    </h1>
+
+    <!-- Tagline / support line -->
+    <p class="mt-4 max-w-2xl text-lg leading-relaxed text-white/85">
+      {editionTagline}
+    </p>
+
+    <!-- Countdown — client:visible, reduced-motion friendly -->
+    <div class="mt-8 max-w-sm">
+      <PtdCountdown
+        client:visible
+        lang={lang}
+        targetDate={targetDate}
+        endDate={endDate}
+        variant="hub"
+      />
+    </div>
+
+    <!-- CTAs -->
+    <div class="mt-8 flex flex-wrap gap-3">
+      <!-- Primary CTA -->
+      <a
+        href={editionHref}
+        class="inline-flex min-h-[44px] items-center rounded-full bg-ptt-primary px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-ptt-primary-strong focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark"
+      >
+        {t.indexStagePrimaryCta}
+      </a>
+
+      <!-- Secondary: CFS -->
+      <a
+        href={`${prefix}/call-for-speakers/`}
+        class="inline-flex min-h-[44px] items-center rounded-full border border-white/50 px-6 py-2.5 text-sm font-semibold text-white/90 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        {t.indexCfsCta}
+      </a>
+
+      <!-- Secondary: Sponsor -->
+      <a
+        href={`${prefix}/sponsor-us/`}
+        class="inline-flex min-h-[44px] items-center text-sm font-semibold text-white/70 underline-offset-2 transition hover:text-white hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        {t.indexSponsorCta}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/components/pereira-tech-days/PtdHubPastRow.astro
+++ b/src/components/pereira-tech-days/PtdHubPastRow.astro
@@ -1,0 +1,169 @@
+---
+/**
+ * Hub past-edition row — single horizontal band for a past Pereira Tech Day.
+ * Desktop: image (~45%) + copy/CTA side by side.
+ * Mobile: stacks vertically as one continuous story (not a card grid).
+ */
+
+import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
+import { getEditionStartDate, type PereiraTechDay } from '@/lib/pereiraTechDay';
+import { getTranslations } from '@/lib/translations';
+
+interface Props {
+  edition: PereiraTechDay;
+  lang: Language;
+}
+
+const { edition, lang } = Astro.props;
+const t = getTranslations(lang).ptdPage;
+const prefix = getUrlPrefix(lang);
+
+const editionHref = `${prefix}/pereira-tech-days/${edition.data.year}/`;
+const editionTitle = tr(edition.data.title, lang);
+const editionTagline = tr(edition.data.tagline, lang);
+const editionDescription = tr(edition.data.description, lang);
+
+const startDate = getEditionStartDate(edition);
+const dateLong = startDate.toLocaleDateString(
+  lang === 'es' ? 'es-CO' : 'en-US',
+  {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'America/Bogota',
+  }
+);
+
+const heroSrc = edition.data.hero?.src ?? null;
+const heroAlt = edition.data.hero?.alt
+  ? tr(edition.data.hero.alt, lang)
+  : editionTitle;
+
+const accentHex = edition.data.brandKit.paletteLight.accent;
+---
+
+<article
+  class="group relative overflow-hidden bg-ptt-bg-elevated motion-safe:animate-[fadeInUp_0.6s_ease_both]"
+  style={`--past-row-accent: ${accentHex};`}
+>
+  <!-- Decorative accent stripe (top) -->
+  <div
+    class="h-1 w-full"
+    style={`background: ${accentHex};`}
+    aria-hidden="true"
+  >
+  </div>
+
+  <div class="main-container py-12 sm:py-16">
+    <div class="flex flex-col gap-8 md:flex-row md:items-center md:gap-12 lg:gap-16">
+      <!-- Image — ~45% on md+ -->
+      <div class="w-full shrink-0 md:w-[45%]">
+        {
+          heroSrc ? (
+            <a
+              href={editionHref}
+              class="block overflow-hidden rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary"
+              tabindex="-1"
+              aria-hidden="true"
+            >
+              <img
+                src={heroSrc}
+                alt={heroAlt}
+                width={800}
+                height={450}
+                class="aspect-video w-full object-cover transition duration-500 motion-safe:group-hover:scale-[1.02]"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+          ) : (
+            <div
+              class="flex aspect-video w-full items-center justify-center rounded-xl bg-ptt-bg"
+              aria-hidden="true"
+            >
+              <span class="text-5xl font-extrabold text-ptt-secondary/30">
+                {edition.data.year}
+              </span>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Copy + CTA -->
+      <div class="min-w-0 flex-1">
+        <!-- Year badge + eyebrow -->
+        <p
+          class="text-xs font-semibold uppercase tracking-widest text-ptt-secondary"
+        >
+          {t.indexPastRowEyebrow} · {edition.data.year}
+        </p>
+
+        <!-- Title -->
+        <h2
+          class="mt-2 text-2xl font-bold tracking-tight text-ptt sm:text-3xl"
+        >
+          {editionTitle}
+        </h2>
+
+        <!-- Date -->
+        <p class="mt-1 text-sm text-ptt-secondary">
+          {dateLong}
+        </p>
+
+        <!-- Tagline -->
+        <p
+          class="mt-3 text-base font-medium leading-relaxed text-ptt"
+        >
+          {editionTagline}
+        </p>
+
+        <!-- Short description (first sentence) -->
+        {
+          editionDescription && (
+            <p class="mt-2 text-sm leading-relaxed text-ptt-secondary line-clamp-3">
+              {editionDescription}
+            </p>
+          )
+        }
+
+        <!-- CTA -->
+        <div class="mt-6">
+          <a
+            href={editionHref}
+            class="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-ptt-primary px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-ptt-primary-strong focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark"
+          >
+            {t.indexPastRowCta}
+            <svg
+              aria-hidden="true"
+              class="h-4 w-4 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9 5l7 7-7 7"
+              >
+              </path>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>
+
+<style>
+  @keyframes fadeInUp {
+    from {
+      opacity: 0;
+      transform: translateY(24px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/src/components/pereira-tech-days/PtdHubPastRow.astro
+++ b/src/components/pereira-tech-days/PtdHubPastRow.astro
@@ -71,7 +71,7 @@ const accentHex = edition.data.brandKit.paletteLight.accent;
                 alt={heroAlt}
                 width={800}
                 height={450}
-                class="aspect-video w-full object-cover transition duration-500 motion-safe:group-hover:scale-[1.02]"
+                class="aspect-video w-full object-cover transition duration-500 motion-safe:group-hover:scale-[1.02] motion-reduce:transition-none"
                 loading="lazy"
                 decoding="async"
               />

--- a/src/content/pages/en/pereira-tech-days.md
+++ b/src/content/pages/en/pereira-tech-days.md
@@ -1,21 +1,20 @@
 ---
 title: "Pereira Tech Days"
-description: "The community flagship annual conference in Pereira — keynotes, lightning talks, panels, and networking. Browse the 2024 archive and the upcoming August 22, 2026 edition at UTP."
-lastUpdated: 2026-08-06
+description: "The community flagship annual conference in Pereira — a full-bleed stage for the upcoming edition with live countdown, a past-edition showcase row, and links to Call for Speakers and sponsorship."
+lastUpdated: 2026-08-07
 ---
 
 # Pereira Tech Days
 
 The community flagship annual conference — one full day of keynotes, lightning talks, panels, and networking in Pereira, Risaralda.
 
-The catalog at [/en/pereira-tech-days](/en/pereira-tech-days) includes:
+The hub at [/en/pereira-tech-days](/en/pereira-tech-days) follows this layout:
 
-- Atmospheric hero with the **Pereira Tech Days** brand
-- Data-backed stats (editions, years running, founding year)
-- Featured edition story with a dynamic CTA to the current year
-- Past editions archive
-- Links to Call for Speakers and sponsorship
-- `ItemList` + `EventSeries` JSON-LD
+1. **Featured stage** — full-bleed dark section presenting the upcoming edition as the grand first composition, with live D/H/M/S countdown to the event start, a primary CTA to the edition detail page, and secondary links to Call for Speakers and sponsorship.
+2. **Past-edition row** — one horizontal band per completed edition (image ~45% + copy/CTA on `md+`; stacks on mobile). Not a card grid.
+3. **Join strip** — slim community CTA linking back to the PTT home and meetups.
+
+No `EditionScope` is applied on this route — global PTT tokens only.
 
 ## Upcoming edition
 
@@ -24,6 +23,14 @@ The catalog at [/en/pereira-tech-days](/en/pereira-tech-days) includes:
 ## Past edition
 
 - [Pereira Tech Day 2024](/en/pereira-tech-days/2024)
+
+## Empty state
+
+When no upcoming edition exists, the stage shows a series-intro title with a CTA to the latest past edition and to the Call for Speakers page.
+
+## JSON-LD
+
+Both `ItemList` and `EventSeries` structured data are injected into the hub page.
 
 ## Spanish
 

--- a/src/content/pages/es/pereira-tech-days.md
+++ b/src/content/pages/es/pereira-tech-days.md
@@ -1,21 +1,20 @@
 ---
 title: "Pereira Tech Days"
-description: "La conferencia anual insignia de la comunidad en Pereira — keynotes, lightning talks, paneles y networking. Consulta el archivo 2024 y la próxima edición del 22 de agosto de 2026 en la UTP."
-lastUpdated: 2026-08-06
+description: "La conferencia anual insignia de la comunidad en Pereira — un escenario principal para la próxima edición con cuenta regresiva en vivo, una fila de edición pasada y enlaces a Call for Speakers y patrocinio."
+lastUpdated: 2026-08-07
 ---
 
 # Pereira Tech Days
 
 La conferencia anual insignia de la comunidad — un día completo de keynotes, lightning talks, paneles y networking en Pereira, Risaralda.
 
-La página de catálogo en [/pereira-tech-days](/pereira-tech-days) incluye:
+El hub en [/pereira-tech-days](/pereira-tech-days) sigue esta estructura:
 
-- Hero atmosférico con la marca **Pereira Tech Days**
-- Estadísticas respaldadas por datos (ediciones, años activos, año de inicio)
-- Historia de la edición destacada con CTA dinámico al año vigente
-- Archivo de ediciones pasadas
-- Enlaces a Call for Speakers y patrocinio
-- JSON-LD `ItemList` + `EventSeries`
+1. **Escenario destacado** — sección oscura a pantalla completa que presenta la próxima edición como la gran primera composición, con cuenta regresiva D/H/M/S en vivo hasta el inicio del evento, un CTA principal a la página de la edición y enlaces secundarios a Call for Speakers y patrocinio.
+2. **Fila de edición anterior** — una banda horizontal por cada edición completada (imagen ~45% + texto/CTA en `md+`; apilado en móvil). No es una cuadrícula de tarjetas.
+3. **Franja de unión** — CTA comunitario discreto con enlace a la página principal de PTT y meetups.
+
+No se aplica `EditionScope` en esta ruta — solo tokens globales de PTT.
 
 ## Próxima edición
 
@@ -24,6 +23,14 @@ La página de catálogo en [/pereira-tech-days](/pereira-tech-days) incluye:
 ## Edición pasada
 
 - [Pereira Tech Day 2024](/pereira-tech-days/2024)
+
+## Estado vacío
+
+Cuando no hay ninguna edición próxima, el escenario muestra un título introductorio de la serie con un CTA a la última edición pasada y a la página de Call for Speakers.
+
+## JSON-LD
+
+Se inyectan datos estructurados `ItemList` y `EventSeries` en la página del hub.
 
 ## English
 

--- a/src/lib/pereiraTechDay.ts
+++ b/src/lib/pereiraTechDay.ts
@@ -152,6 +152,17 @@ export const getEditionEndIso = (
   return undefined;
 };
 
+/**
+ * Returns countdown ISO timestamps for the hub's `PtdCountdown variant="hub"`.
+ * Wraps `getEditionStartIso` / `getEditionEndIso` so call-sites stay simple.
+ */
+export const getEditionCountdownTargets = (
+  edition: PereiraTechDay
+): { targetDate: string; endDate?: string } => ({
+  targetDate: getEditionStartIso(edition),
+  endDate: getEditionEndIso(edition),
+});
+
 /** Whether the edition is the upcoming flagship template (announced / RSVP). */
 export const isUpcomingEdition = (edition: PereiraTechDay): boolean =>
   edition.data.status === 'announced' || edition.data.status === 'rsvp-open';

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -884,6 +884,12 @@ Browse the catalog, attend the next meetup, or get in touch if you want to speak
     editionNavLabel: 'Pereira Tech Day navigation',
     previousEditions: 'Other editions',
     allEditions: 'All editions',
+    indexStagePrimaryCta: 'View this edition',
+    indexPastRowEyebrow: 'Past edition',
+    indexPastRowCta: 'View edition recap',
+    indexNoUpcomingTitle: 'A year of bold talks',
+    indexNoUpcomingIntro:
+      'The next Pereira Tech Day is in the making. Follow the community to be the first to know.',
   },
 
   // Blog post engagement

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -889,6 +889,12 @@ Explora el catálogo, asiste al próximo meetup o escríbenos si quieres ser pon
     editionNavLabel: 'Navegación de Pereira Tech Day',
     previousEditions: 'Otras ediciones',
     allEditions: 'Todas las ediciones',
+    indexStagePrimaryCta: 'Ver esta edición',
+    indexPastRowEyebrow: 'Edición anterior',
+    indexPastRowCta: 'Ver resumen de la edición',
+    indexNoUpcomingTitle: 'Un año de charlas memorables',
+    indexNoUpcomingIntro:
+      'El próximo Pereira Tech Day está en camino. Síguenos para enterarte primero.',
   },
 
   // Blog post engagement

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -556,6 +556,11 @@ export interface SiteTranslations {
     editionNavLabel: string;
     previousEditions: string;
     allEditions: string;
+    indexStagePrimaryCta: string;
+    indexPastRowEyebrow: string;
+    indexPastRowCta: string;
+    indexNoUpcomingTitle: string;
+    indexNoUpcomingIntro: string;
   };
 
   // Blog post engagement

--- a/tests/unit/lib/pereiraTechDay.test.ts
+++ b/tests/unit/lib/pereiraTechDay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { PereiraTechDay } from '@/lib/pereiraTechDay';
 import {
   buildEditionThemeCss,
+  getEditionCountdownTargets,
   getEditionEndIso,
   getEditionFontPackages,
   getEditionStartDate,
@@ -301,6 +302,38 @@ describe('pereiraTechDay helpers', () => {
         title: { en: 'Your first talk', es: 'Tu primera charla' },
       },
     ]);
+  });
+
+  // getEditionCountdownTargets — hub countdown helper
+
+  it('getEditionCountdownTargets returns targetDate matching getEditionStartIso', () => {
+    const edition = mockEdition();
+    const { targetDate } = getEditionCountdownTargets(edition);
+    expect(targetDate).toBe(getEditionStartIso(edition));
+  });
+
+  it('getEditionCountdownTargets returns endDate matching getEditionEndIso', () => {
+    const edition = mockEdition(); // has endTime: '14:00'
+    const { endDate } = getEditionCountdownTargets(edition);
+    expect(endDate).toBe(getEditionEndIso(edition));
+    expect(endDate).toBeDefined();
+  });
+
+  it('getEditionCountdownTargets returns endDate undefined for single-day edition with no endTime', () => {
+    const edition = mockEdition({ endTime: undefined });
+    const { endDate } = getEditionCountdownTargets(edition);
+    expect(endDate).toBeUndefined();
+  });
+
+  it('getEditionCountdownTargets returns both targetDate and endDate for date-range edition', () => {
+    const edition = mockEdition({
+      date: { start: new Date('2026-08-22'), end: new Date('2026-08-23') },
+      startTime: '09:00',
+      endTime: '18:00',
+    });
+    const { targetDate, endDate } = getEditionCountdownTargets(edition);
+    expect(targetDate).toMatch(/2026-08-22/);
+    expect(endDate).toMatch(/2026-08-23/);
   });
 
   it('normalizeLightningTalks accepts a mix of both shapes', () => {


### PR DESCRIPTION
## Summary
- Redesign `/pereira-tech-days` around the live **2026** edition (cinematic stage + live countdown) and a dignified **single-row** showcase for **2024** — no multi-year card catalog.
- New components: `PtdHubFeaturedStage`, `PtdHubPastRow`; `PtdCountdown` gains `variant="hub"` for dark-stage AA contrast.
- i18n + agent markdown, docs (`PEREIRA_TECH_DAYS.md`, IA naming fix), `getEditionCountdownTargets` helper + tests.

## Test plan
- [ ] Open `/pereira-tech-days` and `/en/pereira-tech-days` — first viewport shows 2026 + ticking countdown
- [ ] Past section is one horizontal band (not a card grid)
- [ ] Light + dark, mobile + desktop; reduced-motion does not break layout
- [ ] CTAs: edition detail, CFS, sponsor-us, join strip
- [ ] `pnpm run biome:check && pnpm run astro:check && pnpm run test`

Plan: `PLAN_ptd_hub_page_redesign` (11/11)


Made with [Cursor](https://cursor.com)