### PR TITLE
feat(community): restructure Equipo page — flat organizers + unified alumni

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 | Blog Lifecycle | [Blog Content Lifecycle](docs/features/BLOG_CONTENT_LIFECYCLE.md) | End-to-end blog workflow |
 | Certificates | [Certificates](docs/features/CERTIFICATES.md) | Individual diploma pages, print/PDF, verify UX, fixtures |
 | Authors | [Authors](docs/features/AUTHORS.md) | Multi-author support, YAML schema, AuthorCard, JSON-LD |
+| Contributors | [Contributors](docs/features/CONTRIBUTORS.md) | Equipo directory — flat organizers + unified alumni |
 | Writing Voice | [Writing Voice Guide](docs/WRITING_VOICE_GUIDE.md) | Anti-AI-slop checklist, PTT voice, vocabulary blocklist |
 | Content QA | [Content QA Checklist](docs/features/CONTENT_QA_CHECKLIST.md) | Bilingual parity, orthography, SEO/AEO, automated gates |
 | Writing Craft | [Writing Craft Guide](docs/WRITING_CRAFT_GUIDE.md) | Narrative structure, fact verification, quote handling, refinement |

--- a/docs/INFORMATION_ARCHITECTURE.md
+++ b/docs/INFORMATION_ARCHITECTURE.md
@@ -50,8 +50,8 @@ match this IA, you are creating drift.
 | ~~Talk detail~~ | `/talks/{slug}` → 301 `/meetups` | `/en/talks/{slug}` → 301 `/en/meetups` | `talks` | `talks/[slug].astro` (redirect stub) | removed (Task 22) | n/a |
 | Community Calendar (stub) | `/calendar` | `/es/calendar` | static | `calendar.astro` | `CalendarPage.astro` (full GCal hub lands in Tasks 63–70) | pending |
 | Allied Communities (stub) | `/communities` | `/es/communities` | static | `communities.astro` | `CommunitiesPage.astro` (full page craft lands in Tasks 71–72) | pending |
-| Contributors catalog | `/contributors` | `/es/contributors` | `contributors` | `contributors/index.astro` | `ContributorsCatalogPage.astro` | yes |
-| Contributor profile | `/contributors/{slug}` | `/es/contributors/{slug}` | `contributors` | `contributors/[slug].astro` | `ContributorProfilePage.astro` | per-slug `.md` |
+| Contributors catalog | `/contributors` | `/en/contributors` | `contributors` | `contributors/index.astro` | `ContributorsPage.astro` (flat organizers + unified alumni) | yes |
+| ~~Contributor profile~~ | not shipped | — | — | — | Future; cards are not linked to `/contributors/{slug}` yet | n/a |
 | Sponsors catalog | `/sponsors` | `/es/sponsors` | `sponsors` | `sponsors/index.astro` | `SponsorsCatalogPage.astro` (grouped by tier) | yes |
 | Sponsor profile | `/sponsors/{slug}` | `/es/sponsors/{slug}` | `sponsors` | `sponsors/[slug].astro` | `SponsorProfilePage.astro` | per-slug `.md` |
 | Channels | `/channels` | `/es/channels` | `channels` | `channels.astro` | `ChannelsPage.astro` | yes |

--- a/docs/features/CONTRIBUTORS.md
+++ b/docs/features/CONTRIBUTORS.md
@@ -1,0 +1,45 @@
+# Contributors (Equipo) — Feature Guide
+
+The `/contributors` page is the public **Team** directory for Pereira Tech Talks (nav label: Equipo / Team).
+
+## Routes
+
+| Lang | URL |
+|------|-----|
+| ES (primary) | `/contributors` |
+| EN | `/en/contributors` |
+
+Page component: `src/components/pages/ContributorsPage.astro`  
+Card: `src/components/cards/ContributorCard.astro`  
+Helpers: `src/lib/contributor.ts`
+
+## Content
+
+YAML entries in `src/content/contributors/{slug}.yaml` (schema in `src/content.config.ts`).
+
+| Field | Notes |
+|-------|--------|
+| `roles` | Enum includes `organizer`, `alumni`, `contributor`, `mentor`, `founding-organizer`, etc. |
+| `inactiveSince` | If set → person appears in the **past** section |
+| `role` / `bio` | Localized `{ en, es }` display strings |
+| `order` | Sort key within a section |
+
+**UI IA (v3 Equipo redesign):**
+
+1. **Equipo organizador** — active people with `organizer` (or legacy `founding-organizer`) — **one flat grid** (no founder/mentor/contributor subsections).
+2. **Alumni y organizadores anteriores** — everyone with `inactiveSince` — **one flat grid**.
+
+The Zod enum may still allow `mentor` / `founding-organizer`, but the page does **not** segment those roles into separate sections.
+
+## Adding someone
+
+1. Add `src/content/contributors/{english-slug}.yaml` + avatar under `public/images/contributors/`.
+2. For current organizers: `roles: [organizer]`, omit `inactiveSince`.
+3. For past / alumni: set `inactiveSince` and usually include `alumni`.
+4. Keep **slugs stable** — PTD editions reference them via `getContributorsBySlugs`.
+
+## Related
+
+- PTD team grids reuse `getContributorsBySlugs`
+- Authors collection is separate (`docs/features/AUTHORS.md`)
+- Agent markdown: `/contributors/index.md` (and `/en/...`)

--- a/src/components/cards/ContributorCard.astro
+++ b/src/components/cards/ContributorCard.astro
@@ -1,7 +1,6 @@
 ---
 /**
- * PTT v3.0.0 contributor card — preview for a `contributors` collection
- * entry (organizers, vertical leads, mentors, etc).
+ * Contributor card for the Equipo directory (organizers + alumni).
  */
 
 import type { CollectionEntry } from 'astro:content';
@@ -11,14 +10,17 @@ interface Props {
   contributor: CollectionEntry<'contributors'>;
   lang: Language;
   loading?: 'lazy' | 'eager';
+  /** Quieter treatment for past / alumni grid. */
+  muted?: boolean;
 }
 
-const { contributor, lang, loading = 'lazy' } = Astro.props;
+const { contributor, lang, loading = 'lazy', muted = false } = Astro.props;
 
 const role = tr(contributor.data.role, lang);
 const bio = tr(contributor.data.bio, lang);
 const avatar = contributor.data.avatar;
 const social = contributor.data.social ?? {};
+const pronouns = contributor.data.pronouns;
 
 const roleLabels: Record<string, { en: string; es: string }> = {
   'founding-organizer': {
@@ -35,36 +37,64 @@ const roleLabels: Record<string, { en: string; es: string }> = {
   'conduct-team': { en: 'Conduct team', es: 'Equipo de conducta' },
   alumni: { en: 'Alumni', es: 'Alumni' },
 };
+
+const displayRoles =
+  contributor.data.roles.length > 1
+    ? contributor.data.roles.filter((r) => r !== 'alumni')
+    : contributor.data.roles;
+
+const portraitAlt =
+  lang === 'es'
+    ? `Retrato de ${contributor.data.name}`
+    : `Portrait of ${contributor.data.name}`;
 ---
 
-<article class="group flex h-full flex-col items-center rounded-2xl bg-ptt-bg-elevated shadow-sm ring-1 ring-ptt-border p-6 text-center transition hover:shadow-lg hover:ring-ptt-primary/30">
-  <div class="relative h-24 w-24 overflow-hidden rounded-full bg-gradient-to-br from-ptt-primary/20 to-ptt-bg-dark/20 ring-2 ring-ptt-bg-elevated shadow-sm">
-    <img decoding="async"
+<article
+  class:list={[
+    'group flex h-full flex-col items-center rounded-2xl p-6 text-center transition motion-reduce:transition-none',
+    muted
+      ? 'bg-ptt-bg-elevated/80 shadow-none ring-1 ring-ptt-border/70 hover:ring-ptt-border dark:bg-ptt-bg-dark/40'
+      : 'bg-ptt-bg-elevated shadow-sm ring-1 ring-ptt-border hover:shadow-lg hover:ring-ptt-primary/30',
+  ]}
+>
+  <div
+    class="relative h-24 w-24 overflow-hidden rounded-full bg-gradient-to-br from-ptt-primary/20 to-ptt-bg-dark/20 ring-2 ring-ptt-bg-elevated shadow-sm"
+  >
+    <img
+      decoding="async"
       src={avatar}
-      alt={`Portrait of ${contributor.data.name}`}
+      alt={portraitAlt}
       width="96"
       height="96"
       loading={loading}
-      class="h-full w-full object-cover" />
+      class="h-full w-full object-cover"
+    />
   </div>
   <h3 class="mt-4 text-base font-semibold text-ptt">
     {contributor.data.name}
   </h3>
-  <p class="mt-1 text-sm text-ptt-primary dark:text-ptt-primary-dark font-medium">
+  {
+    pronouns && (
+      <p class="mt-0.5 text-xs text-ptt-secondary">{pronouns}</p>
+    )
+  }
+  <p class="mt-1 text-sm font-medium text-ptt-primary dark:text-ptt-primary-dark">
     {role}
   </p>
   <p class="mt-2 text-xs text-ptt-secondary line-clamp-3">
     {bio}
   </p>
-  <ul class="mt-3 flex flex-wrap justify-center gap-1.5">
-    {
-      contributor.data.roles.map((r) => (
-        <li class="inline-flex items-center rounded-full bg-ptt-primary-soft px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ptt-secondary">
-          {roleLabels[r]?.[lang] ?? r}
-        </li>
-      ))
-    }
-  </ul>
+  {
+    displayRoles.length > 1 && (
+      <ul class="mt-3 flex flex-wrap justify-center gap-1.5">
+        {displayRoles.map((r) => (
+          <li class="inline-flex items-center rounded-full bg-ptt-primary-soft px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ptt-secondary">
+            {roleLabels[r]?.[lang] ?? r}
+          </li>
+        ))}
+      </ul>
+    )
+  }
   {
     Object.keys(social).length > 0 && (
       <ul class="mt-4 flex gap-3 text-ptt-secondary">
@@ -75,7 +105,7 @@ const roleLabels: Record<string, { en: string; es: string }> = {
               target="_blank"
               rel="noopener noreferrer"
               class="hover:text-ptt-primary dark:hover:text-ptt-primary-dark"
-              aria-label={`${contributor.data.name} on GitHub`}
+              aria-label={`${contributor.data.name} · GitHub`}
             >
               <svg aria-hidden="true" class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
@@ -90,7 +120,7 @@ const roleLabels: Record<string, { en: string; es: string }> = {
               target="_blank"
               rel="noopener noreferrer"
               class="hover:text-ptt-primary dark:hover:text-ptt-primary-dark"
-              aria-label={`${contributor.data.name} on LinkedIn`}
+              aria-label={`${contributor.data.name} · LinkedIn`}
             >
               <svg aria-hidden="true" class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.852 3.37-1.852 3.601 0 4.267 2.37 4.267 5.455v6.288zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
@@ -105,7 +135,7 @@ const roleLabels: Record<string, { en: string; es: string }> = {
               target="_blank"
               rel="noopener noreferrer"
               class="hover:text-ptt-primary dark:hover:text-ptt-primary-dark"
-              aria-label={`${contributor.data.name} on X`}
+              aria-label={`${contributor.data.name} · X`}
             >
               <svg aria-hidden="true" class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
@@ -120,7 +150,11 @@ const roleLabels: Record<string, { en: string; es: string }> = {
               target="_blank"
               rel="noopener noreferrer"
               class="hover:text-ptt-primary dark:hover:text-ptt-primary-dark"
-              aria-label={`${contributor.data.name} website`}
+              aria-label={
+                lang === 'es'
+                  ? `Sitio web de ${contributor.data.name}`
+                  : `${contributor.data.name} website`
+              }
             >
               <svg aria-hidden="true" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0zM3.6 9h16.8M3.6 15h16.8M12 3a14.5 14.5 0 010 18M12 3a14.5 14.5 0 000 18" />

--- a/src/components/pages/ContributorsPage.astro
+++ b/src/components/pages/ContributorsPage.astro
@@ -1,7 +1,6 @@
 ---
 /**
- * PTT v3.0.0 contributors directory page (shared between EN and ES).
- * Current team prominently; alumni and past organizers in a dedicated section.
+ * PTT v3.0.0 Equipo / Team directory — flat current organizers + unified past.
  */
 
 import ContributorCard from '@/components/cards/ContributorCard.astro';
@@ -10,7 +9,10 @@ import EmptyState from '@/components/ui/EmptyState.astro';
 import Eyebrow from '@/components/ui/Eyebrow.astro';
 import Section from '@/components/ui/Section.astro';
 import MainLayout from '@/layouts/MainLayout.astro';
-import { getActiveContributors, getPastContributors } from '@/lib/contributor';
+import {
+  getCurrentTeamOrganizers,
+  getPastTeamMembers,
+} from '@/lib/contributor';
 import { getUrlPrefix, type Language } from '@/lib/i18n';
 import { getTranslations } from '@/lib/translations';
 
@@ -23,69 +25,9 @@ const t = getTranslations(lang);
 const cp = t.contributorsPage;
 const prefix = getUrlPrefix(lang);
 
-const currentContributors = await getActiveContributors();
-const pastContributors = await getPastContributors();
-
-type Role =
-  | 'founding-organizer'
-  | 'organizer'
-  | 'vertical-lead'
-  | 'mentor'
-  | 'sponsor-liaison'
-  | 'press-lead'
-  | 'conduct-team'
-  | 'contributor'
-  | 'alumni';
-
-const roleOrder: Role[] = [
-  'founding-organizer',
-  'organizer',
-  'vertical-lead',
-  'mentor',
-  'conduct-team',
-  'press-lead',
-  'sponsor-liaison',
-  'contributor',
-];
-
-const alumniRoleOrder: Role[] = ['alumni', 'contributor'];
-
-const roleTitles: Record<Role, { en: string; es: string }> = {
-  'founding-organizer': {
-    en: 'Founding organizers',
-    es: 'Organizadores fundadores',
-  },
-  organizer: { en: 'Core organizers', es: 'Equipo organizador' },
-  'vertical-lead': { en: 'Vertical leads', es: 'Líderes de programa' },
-  mentor: { en: 'Mentors', es: 'Mentores' },
-  'conduct-team': { en: 'Conduct team', es: 'Equipo de conducta' },
-  'press-lead': { en: 'Press leads', es: 'Equipo de prensa' },
-  'sponsor-liaison': {
-    en: 'Sponsor liaisons',
-    es: 'Enlaces con patrocinadores',
-  },
-  contributor: { en: 'Contributors', es: 'Contribuidores' },
-  alumni: { en: 'Alumni', es: 'Alumni' },
-};
-
-function groupContributors(
-  contributors: Awaited<ReturnType<typeof getActiveContributors>>,
-  roles: Role[]
-) {
-  const seen = new Set<string>();
-  return roles
-    .map((role) => {
-      const inRole = contributors.filter(
-        (c) => !seen.has(c.id) && c.data.roles.includes(role)
-      );
-      for (const c of inRole) seen.add(c.id);
-      return { role, contributors: inRole };
-    })
-    .filter((group) => group.contributors.length > 0);
-}
-
-const currentByRole = groupContributors(currentContributors, roleOrder);
-const pastByRole = groupContributors(pastContributors, alumniRoleOrder);
+const currentOrganizers = await getCurrentTeamOrganizers();
+const pastMembers = await getPastTeamMembers();
+const sinceYear = 2014;
 
 const breadcrumbs = [
   { label: lang === 'es' ? 'Inicio' : 'Home', href: `${prefix}/` },
@@ -94,46 +36,58 @@ const breadcrumbs = [
 ---
 
 <MainLayout lang={lang} title={cp.title} description={cp.description}>
-  <div class="bg-ptt-bg">
-    <div class="main-container pt-12 sm:pt-16 pb-4">
+  <div class="relative overflow-hidden bg-ptt-bg">
+    <div
+      class="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--ptt-primary)_0%,_transparent_55%)] opacity-[0.07] dark:opacity-[0.12]"
+      aria-hidden="true"
+    >
+    </div>
+    <div class="main-container relative pt-12 sm:pt-16 pb-4">
       <Breadcrumbs items={breadcrumbs} />
     </div>
-    <div class="main-container pt-6 pb-12">
+    <div class="main-container relative pt-6 pb-14 sm:pb-16">
       <Eyebrow>{cp.eyebrow}</Eyebrow>
-      <h1 class="mt-3 text-4xl sm:text-5xl font-bold tracking-tight text-ptt">
+      <h1 class="mt-3 max-w-3xl text-4xl sm:text-5xl font-bold tracking-tight text-ptt">
         {cp.title}
       </h1>
-      <p class="mt-4 max-w-3xl text-lg text-ptt-secondary">
-        {cp.intro(currentContributors.length)}
+      <p class="mt-4 max-w-2xl text-lg text-ptt-secondary">
+        {cp.intro(currentOrganizers.length)}
       </p>
-      <a
-        href={`${prefix}/contact/`}
-        class="mt-6 inline-flex items-center gap-2 rounded-full bg-ptt-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-ptt-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark dark:hover:bg-ptt-primary-dark/90"
-      >
-        {cp.joinLabel}
-      </a>
+      <p class="mt-3 text-sm font-medium text-ptt-secondary">
+        {cp.sinceLabel(sinceYear)}
+      </p>
+      <div class="mt-8 flex flex-wrap items-center gap-3">
+        <a
+          href={`${prefix}/contact/`}
+          class="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-ptt-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-ptt-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark dark:hover:bg-ptt-primary-dark/90"
+        >
+          {cp.joinLabel}
+        </a>
+        <a
+          href={`${prefix}/contributing/`}
+          class="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-ptt-border bg-ptt-bg-elevated px-5 py-2.5 text-sm font-semibold text-ptt transition-colors hover:border-ptt-primary/40 hover:bg-ptt-primary-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:border-white/15 dark:bg-ptt-bg-dark dark:text-white dark:hover:bg-white/10"
+        >
+          {cp.contributeLabel}
+        </a>
+      </div>
     </div>
   </div>
 
   {
-    currentByRole.length > 0 ? (
+    currentOrganizers.length > 0 ? (
       <Section surface="alt" spacing="lg" title={cp.currentTitle}>
-        <div class="space-y-16">
-          {currentByRole.map(({ role, contributors: group }) => (
-            <div>
-              <h2 class="mb-6 text-2xl font-bold tracking-tight text-ptt">
-                {roleTitles[role][lang]}
-              </h2>
-              <ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 list-none">
-                {group.map((contributor) => (
-                  <li>
-                    <ContributorCard contributor={contributor} lang={lang} />
-                  </li>
-                ))}
-              </ul>
-            </div>
+        <p class="mb-10 max-w-2xl text-ptt-secondary">{cp.currentIntro}</p>
+        <ul class="grid list-none gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {currentOrganizers.map((contributor, index) => (
+            <li>
+              <ContributorCard
+                contributor={contributor}
+                lang={lang}
+                loading={index < 6 ? 'eager' : 'lazy'}
+              />
+            </li>
           ))}
-        </div>
+        </ul>
       </Section>
     ) : (
       <Section surface="alt">
@@ -143,25 +97,20 @@ const breadcrumbs = [
   }
 
   {
-    pastByRole.length > 0 && (
+    pastMembers.length > 0 && (
       <Section spacing="lg" title={cp.pastTitle}>
         <p class="mb-10 max-w-3xl text-ptt-secondary">{cp.pastIntro}</p>
-        <div class="space-y-12">
-          {pastByRole.map(({ role, contributors: group }) => (
-            <div>
-              <h2 class="mb-6 text-xl font-semibold tracking-tight text-ptt-secondary">
-                {roleTitles[role][lang]}
-              </h2>
-              <ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 list-none">
-                {group.map((contributor) => (
-                  <li>
-                    <ContributorCard contributor={contributor} lang={lang} />
-                  </li>
-                ))}
-              </ul>
-            </div>
+        <ul class="grid list-none gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {pastMembers.map((contributor) => (
+            <li class="opacity-90 transition-opacity motion-reduce:transition-none hover:opacity-100">
+              <ContributorCard
+                contributor={contributor}
+                lang={lang}
+                muted
+              />
+            </li>
           ))}
-        </div>
+        </ul>
       </Section>
     )
   }

--- a/src/content/contributors/angelica-aguirre.yaml
+++ b/src/content/contributors/angelica-aguirre.yaml
@@ -1,15 +1,17 @@
-name: Angelica Aguirre
+name: Angélica Aguirre
 pronouns: she/her
 avatar: /images/contributors/angelica-aguirre.png
 roles:
+  - alumni
   - organizer
 role:
-  en: Pereira Tech Day Co-organizer
-  es: Co-organizadora de Pereira Tech Day
+  en: Former Pereira Tech Day Co-organizer
+  es: Organizadora anterior · Pereira Tech Day
 bio:
-  en: Angelica supports Pereira Tech Day organization, attendee experience, and community outreach.
-  es: Angelica apoya la organización de Pereira Tech Day, la experiencia del asistente y la divulgación a la comunidad.
+  en: Angélica supported Pereira Tech Day organization, attendee experience, and community outreach. She remains part of the extended community network.
+  es: Angélica apoyó la organización de Pereira Tech Day, la experiencia del asistente y la divulgación a la comunidad. Sigue en la red extendida de la comunidad.
 social:
   linkedin: "https://www.linkedin.com/in/angelica-aguirre-castro-50abb5110/"
 activeSince: 2023-01-01
-order: 5
+inactiveSince: 2025-12-31
+order: 31

--- a/src/content/contributors/carolina-gomez-trejos.yaml
+++ b/src/content/contributors/carolina-gomez-trejos.yaml
@@ -2,14 +2,16 @@ name: Carolina Gómez Trejos
 pronouns: she/her
 avatar: /images/contributors/carolina-gomez-trejos.jpg
 roles:
+  - alumni
   - organizer
 role:
-  en: Pereira Tech Day Lead Organizer
-  es: Organizadora líder de Pereira Tech Day
+  en: Former Pereira Tech Day Lead Organizer
+  es: Organizadora anterior · Pereira Tech Day
 bio:
-  en: Carolina co-leads Pereira Tech Day production end to end — venue, schedule, speakers, sponsors, and on-site experience.
-  es: "Carolina lidera la producción de Pereira Tech Day de punta a punta: venue, agenda, ponentes, patrocinadores y experiencia en sitio."
+  en: Carolina co-led Pereira Tech Day production end to end — venue, schedule, speakers, sponsors, and on-site experience. She remains part of the extended community network.
+  es: "Carolina lideró la producción de Pereira Tech Day de punta a punta: venue, agenda, ponentes, patrocinadores y experiencia en sitio. Sigue en la red extendida de la comunidad."
 social:
   linkedin: "https://www.linkedin.com/in/carolinagomezt/"
 activeSince: 2023-01-01
-order: 1
+inactiveSince: 2025-12-31
+order: 30

--- a/src/content/contributors/cindy-jimenez.yaml
+++ b/src/content/contributors/cindy-jimenez.yaml
@@ -2,14 +2,16 @@ name: Cindy Jiménez
 pronouns: she/her
 avatar: /images/contributors/cindy-jimenez.jpeg
 roles:
+  - alumni
   - contributor
 role:
-  en: Collaborator · Pereira Tech Day 2024
-  es: Colaboradora · Pereira Tech Day 2024
+  en: Former Collaborator · Pereira Tech Day 2024
+  es: Colaboradora anterior · Pereira Tech Day 2024
 bio:
   en: Collaborator on Pereira Tech Day 2024, supporting logistics and community engagement for the annual conference.
   es: Colaboradora de Pereira Tech Day 2024, apoyando logística y engagement de la comunidad en la conferencia anual.
 social:
   linkedin: "https://www.linkedin.com/in/cindy-jimenez-s/"
 activeSince: 2024-01-01
-order: 51
+inactiveSince: 2025-12-31
+order: 42

--- a/src/content/contributors/leiver-campeon.yaml
+++ b/src/content/contributors/leiver-campeon.yaml
@@ -2,14 +2,16 @@ name: Leiver Campeón
 pronouns: he/him
 avatar: /images/contributors/leiver-campeon.jpg
 roles:
+  - alumni
   - contributor
 role:
-  en: Collaborator · Pereira Tech Day 2024
-  es: Colaborador · Pereira Tech Day 2024
+  en: Former Collaborator · Pereira Tech Day 2024
+  es: Colaborador anterior · Pereira Tech Day 2024
 bio:
   en: Collaborator on Pereira Tech Day 2024, supporting the organizing team behind the flagship conference.
   es: Colaborador de Pereira Tech Day 2024, apoyando al equipo organizador de la conferencia insignia.
 social:
   linkedin: "https://www.linkedin.com/in/leiverandres/"
 activeSince: 2024-01-01
-order: 50
+inactiveSince: 2025-12-31
+order: 41

--- a/src/content/contributors/lizeth-franco.yaml
+++ b/src/content/contributors/lizeth-franco.yaml
@@ -1,13 +1,15 @@
 name: Lizeth Franco
 avatar: /images/contributors/lizeth-franco.jpeg
 roles:
+  - alumni
   - contributor
 role:
-  en: Pereira Tech Day Collaborator
-  es: Colaboradora de Pereira Tech Day
+  en: Former Pereira Tech Day Collaborator
+  es: Colaboradora anterior · Pereira Tech Day
 bio:
-  en: "Lizeth collaborates with the Pereira Tech Day team, supporting the production of the community's annual conference."
-  es: "Lizeth colabora con el equipo de Pereira Tech Day, apoyando la producción de la conferencia anual de la comunidad."
+  en: "Lizeth collaborated with the Pereira Tech Day team, supporting the production of the community's annual conference."
+  es: "Lizeth colaboró con el equipo de Pereira Tech Day, apoyando la producción de la conferencia anual de la comunidad."
 social:
   linkedin: "https://www.linkedin.com/in/lizethvictoria/"
-order: 19
+inactiveSince: 2025-12-31
+order: 40

--- a/src/content/contributors/sergio-estrella.yaml
+++ b/src/content/contributors/sergio-estrella.yaml
@@ -2,14 +2,14 @@ name: Sergio Estrella
 pronouns: he/him
 avatar: /images/contributors/sergio-estrella.png
 roles:
-  - mentor
+  - organizer
   - speaker
 role:
-  en: Speaker School Mentor
-  es: Mentor de Speaker School
+  en: Organizer · Pereira Tech Talks
+  es: Organizador · Pereira Tech Talks
 bio:
-  en: "Sergio mentors new technical speakers through the Speaker School, drawing on years of public speaking and product practice."
-  es: "Sergio acompaña a nuevas voces técnicas como mentor de la Escuela de Speakers, apoyándose en años de práctica en público speaking y producto."
+  en: "Sergio organizes with Pereira Tech Talks and supports new technical speakers through the Speaker School, drawing on years of public speaking and product practice."
+  es: "Sergio organiza con Pereira Tech Talks y acompaña a nuevas voces técnicas en la Escuela de Speakers, apoyándose en años de práctica en speaking en público y producto."
 social:
   website: "https://sergioestrella.com/"
 activeSince: 2023-01-01

--- a/src/content/contributors/sergio-florez.yaml
+++ b/src/content/contributors/sergio-florez.yaml
@@ -2,13 +2,13 @@ name: Sergio Alexander Florez Galeano
 pronouns: he/him
 avatar: /images/contributors/sergio-florez.png
 roles:
-  - founding-organizer
+  - organizer
 role:
-  en: Co-founder · Pereira Tech Talks
-  es: Cofundador · Pereira Tech Talks
+  en: Organizer · Pereira Tech Talks
+  es: Organizador · Pereira Tech Talks
 bio:
-  en: Co-founder of Pereira Tech Talks. Builds the community website, leads the Speaker School, and obsesses over the craft of community-building.
-  es: Cofundador de Pereira Tech Talks. Construye el sitio web de la comunidad, lidera la Speaker School y se obsesiona con el oficio de construir comunidad.
+  en: Organizer of Pereira Tech Talks. Builds the community website, leads the Speaker School, and obsesses over the craft of community-building.
+  es: Organizador de Pereira Tech Talks. Construye el sitio web de la comunidad, lidera la Speaker School y se obsesiona con el oficio de construir comunidad.
 social:
   linkedin: "https://www.linkedin.com/company/pereira-tech-talks/"
   github: "https://github.com/pereira-tech-talks"

--- a/src/lib/contributor.ts
+++ b/src/lib/contributor.ts
@@ -72,3 +72,30 @@ export const getOrganizers = async (): Promise<Contributor[]> => {
       c.data.roles.includes('founding-organizer')
   );
 };
+
+/** Active organizers for the Equipo page (flat current-team grid). */
+export const filterCurrentTeamOrganizers = (
+  contributors: Contributor[]
+): Contributor[] =>
+  sortContributors(
+    filterActiveContributors(contributors).filter(
+      (c) =>
+        c.data.roles.includes('organizer') ||
+        c.data.roles.includes('founding-organizer')
+    )
+  );
+
+/** Past / alumni members for the unified Equipo past section. */
+export const filterPastTeamMembers = (
+  contributors: Contributor[]
+): Contributor[] => sortContributors(filterPastContributors(contributors));
+
+export const getCurrentTeamOrganizers = async (): Promise<Contributor[]> => {
+  const all = await getContributors();
+  return filterCurrentTeamOrganizers(all);
+};
+
+export const getPastTeamMembers = async (): Promise<Contributor[]> => {
+  const all = await getContributors();
+  return filterPastTeamMembers(all);
+};

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -550,15 +550,19 @@ Browse the catalog, attend the next meetup, or get in touch if you want to speak
   contributorsPage: {
     title: 'Team and community',
     description:
-      'Meet the organizers, program leads, mentors, and volunteers who keep Pereira Tech Talks running — current team and alumni network.',
+      'Meet the organizing team behind Pereira Tech Talks and the people who shaped earlier chapters — the humans behind the meetups and Pereira Tech Day.',
     eyebrow: 'People',
     intro: (count) =>
-      `${count} active people make up the extended community team. Want to join? Reach out.`,
-    currentTitle: 'Current team',
+      `${count} active organizers keep the community running day to day. Want to join? Write to us or see how to contribute.`,
+    sinceLabel: (year) => `Building community in Pereira since ${year}.`,
+    currentTitle: 'Organizing team',
+    currentIntro:
+      'The people who coordinate meetups, Pereira Tech Day, programs, and the day-to-day operations of Pereira Tech Talks.',
     pastTitle: 'Alumni and past organizers',
     pastIntro:
-      'Former organizers and contributors who shaped earlier chapters of the community. They remain part of the extended network.',
+      'Former organizers and collaborators from earlier chapters. They remain part of the extended community network.',
     joinLabel: 'Join the team',
+    contributeLabel: 'How to contribute',
     emptyTitle: 'No team members yet',
     emptyDesc: "We're consolidating the directory. Check back soon.",
   },

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -551,15 +551,19 @@ Explora el catálogo, asiste al próximo meetup o escríbenos si quieres ser pon
   contributorsPage: {
     title: 'Equipo y comunidad',
     description:
-      'Conoce a organizadores, líderes de programa, mentores y voluntarios que sostienen Pereira Tech Talks — equipo actual y red alumni.',
+      'Conoce al equipo organizador de Pereira Tech Talks y a quienes acompañaron capítulos anteriores — personas reales detrás de los meetups y Pereira Tech Day.',
     eyebrow: 'Personas',
     intro: (count) =>
-      `${count} personas activas conforman el equipo extendido de la comunidad. Si quieres unirte, escríbenos.`,
-    currentTitle: 'Equipo actual',
+      `${count} organizadoras y organizadores activos sostienen la comunidad día a día. Si quieres sumarte, escríbenos o revisa cómo contribuir.`,
+    sinceLabel: (year) => `Construyendo comunidad en Pereira desde ${year}.`,
+    currentTitle: 'Equipo organizador',
+    currentIntro:
+      'Quienes coordinan meetups, Pereira Tech Day, programas y la operación diaria de Pereira Tech Talks.',
     pastTitle: 'Alumni y organizadores anteriores',
     pastIntro:
-      'Organizadores y contribuidores de capítulos anteriores de la comunidad. Siguen siendo parte de la red extendida.',
+      'Organizadoras, organizadores y colaboradoras de capítulos anteriores. Siguen siendo parte de la red extendida de la comunidad.',
     joinLabel: 'Únete al equipo',
+    contributeLabel: 'Cómo contribuir',
     emptyTitle: 'Aún no hay miembros registrados',
     emptyDesc: 'Estamos consolidando el directorio. Vuelve pronto.',
   },

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -356,10 +356,13 @@ export interface SiteTranslations {
     description: string;
     eyebrow: string;
     intro: (count: number) => string;
+    sinceLabel: (year: number) => string;
     currentTitle: string;
+    currentIntro: string;
     pastTitle: string;
     pastIntro: string;
     joinLabel: string;
+    contributeLabel: string;
     emptyTitle: string;
     emptyDesc: string;
   };

--- a/src/pages/contributors/index.md.ts
+++ b/src/pages/contributors/index.md.ts
@@ -1,6 +1,10 @@
 import type { APIRoute } from 'astro';
 
-import { getContributors } from '@/lib/contributor';
+import {
+  filterCurrentTeamOrganizers,
+  filterPastTeamMembers,
+  getContributors,
+} from '@/lib/contributor';
 import { serializeGenericToMarkdown } from '@/lib/markdown-for-agents';
 
 const SITE_URL = 'https://pereiratechtalks.org';
@@ -8,20 +12,33 @@ const SITE_URL = 'https://pereiratechtalks.org';
 export const GET: APIRoute = async () => {
   const lang = 'es';
   const contributors = await getContributors();
-  const lines = contributors.map((c) => {
-    const role = c.data.role.es;
-    const roles = c.data.roles.join(', ');
-    return `- **${c.data.name}** — ${role} (${roles})`;
-  });
+  const current = filterCurrentTeamOrganizers(contributors);
+  const past = filterPastTeamMembers(contributors);
+
+  const toLines = (list: typeof contributors): string[] =>
+    list.map((c) => {
+      const role = c.data.role.es;
+      return `- **${c.data.name}** — ${role}`;
+    });
 
   const markdown = serializeGenericToMarkdown({
-    title: 'Contribuyentes — Pereira Tech Talks',
+    title: 'Equipo — Pereira Tech Talks',
     description:
-      'Las personas de la comunidad que hacen posible Pereira Tech Talks: organizadores fundadores, organizadores, líderes de programas, mentores y equipo de conducta.',
+      'Equipo organizador activo de Pereira Tech Talks y alumni / organizadores anteriores. Directorio bilingüe en /contributors.',
     lang,
     canonical: `${SITE_URL}/contributors`,
-    metadata: [['Total de contribuyentes', String(contributors.length)]],
-    sections: [{ heading: 'Todos los contribuyentes', lines }],
+    metadata: [
+      ['Organizadores activos', String(current.length)],
+      ['Alumni y anteriores', String(past.length)],
+      ['Total en directorio', String(contributors.length)],
+    ],
+    sections: [
+      { heading: 'Equipo organizador', lines: toLines(current) },
+      {
+        heading: 'Alumni y organizadores anteriores',
+        lines: toLines(past),
+      },
+    ],
   });
 
   return new Response(markdown, {

--- a/src/pages/en/contributors/index.md.ts
+++ b/src/pages/en/contributors/index.md.ts
@@ -1,6 +1,10 @@
 import type { APIRoute } from 'astro';
 
-import { getContributors } from '@/lib/contributor';
+import {
+  filterCurrentTeamOrganizers,
+  filterPastTeamMembers,
+  getContributors,
+} from '@/lib/contributor';
 import { serializeGenericToMarkdown } from '@/lib/markdown-for-agents';
 
 const SITE_URL = 'https://pereiratechtalks.org';
@@ -8,20 +12,33 @@ const SITE_URL = 'https://pereiratechtalks.org';
 export const GET: APIRoute = async () => {
   const lang = 'en';
   const contributors = await getContributors();
-  const lines = contributors.map((c) => {
-    const role = c.data.role.en;
-    const roles = c.data.roles.join(', ');
-    return `- **${c.data.name}** — ${role} (${roles})`;
-  });
+  const current = filterCurrentTeamOrganizers(contributors);
+  const past = filterPastTeamMembers(contributors);
+
+  const toLines = (list: typeof contributors): string[] =>
+    list.map((c) => {
+      const role = c.data.role.en;
+      return `- **${c.data.name}** — ${role}`;
+    });
 
   const markdown = serializeGenericToMarkdown({
-    title: 'Contributors — Pereira Tech Talks',
+    title: 'Team — Pereira Tech Talks',
     description:
-      'The community members who make Pereira Tech Talks possible: founding organizers, organizers, vertical leads, mentors, and conduct team.',
+      'Active organizing team of Pereira Tech Talks plus alumni and past organizers. Bilingual directory at /en/contributors.',
     lang,
     canonical: `${SITE_URL}/en/contributors`,
-    metadata: [['Total contributors', String(contributors.length)]],
-    sections: [{ heading: 'All contributors', lines }],
+    metadata: [
+      ['Active organizers', String(current.length)],
+      ['Alumni and past', String(past.length)],
+      ['Total in directory', String(contributors.length)],
+    ],
+    sections: [
+      { heading: 'Organizing team', lines: toLines(current) },
+      {
+        heading: 'Alumni and past organizers',
+        lines: toLines(past),
+      },
+    ],
   });
 
   return new Response(markdown, {

--- a/tests/unit/lib/contributor.test.ts
+++ b/tests/unit/lib/contributor.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import type { Contributor } from '@/lib/contributor';
 import {
   filterActiveContributors,
+  filterCurrentTeamOrganizers,
   filterPastContributors,
+  filterPastTeamMembers,
   sortContributors,
 } from '@/lib/contributor';
 
@@ -49,5 +51,57 @@ describe('contributor helpers', () => {
 
     expect(current.map((c) => c.id)).toEqual(['current']);
     expect(past.map((c) => c.id)).toEqual(['past']);
+  });
+
+  it('filterCurrentTeamOrganizers keeps active organizers only', () => {
+    const contributors = [
+      makeContributor('sergio', {
+        roles: ['organizer'],
+        order: 0,
+        name: 'Sergio',
+      }),
+      makeContributor('mentor-only', {
+        roles: ['mentor'],
+        order: 1,
+        name: 'Mentor',
+      }),
+      makeContributor('past-org', {
+        roles: ['alumni', 'organizer'],
+        inactiveSince: new Date('2025-12-31'),
+        order: 2,
+        name: 'Past',
+      }),
+      makeContributor('founder-compat', {
+        roles: ['founding-organizer'],
+        order: 3,
+        name: 'Legacy',
+      }),
+    ];
+
+    expect(filterCurrentTeamOrganizers(contributors).map((c) => c.id)).toEqual([
+      'sergio',
+      'founder-compat',
+    ]);
+  });
+
+  it('filterPastTeamMembers returns everyone with inactiveSince sorted', () => {
+    const contributors = [
+      makeContributor('b', {
+        inactiveSince: new Date('2025-01-01'),
+        order: 2,
+        name: 'B',
+      }),
+      makeContributor('a', {
+        inactiveSince: new Date('2025-01-01'),
+        order: 1,
+        name: 'A',
+      }),
+      makeContributor('active', { order: 0, name: 'Active' }),
+    ];
+
+    expect(filterPastTeamMembers(contributors).map((c) => c.id)).toEqual([
+      'a',
+      'b',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Restructures `/contributors` (Equipo): one flat **organizing team** grid and one unified **alumni / past organizers** section (no founder / mentor / current-contribuidores splits).
- Roster remap: Sergio Florez as organizer; Carolina Gómez + Angélica Aguirre + Lizeth/Leiver/Cindy moved to past; Sergio Estrella as organizer.
- Hero dual CTAs (join + contribute), card polish, i18n, unit tests, and `docs/features/CONTRIBUTORS.md`.

## Test plan
- [ ] Open `/contributors` — confirm no “Organizadores fundadores” / “Mentores” / current “Contribuidores” sections
- [ ] Confirm Florez title is Organizador; Estrella in current team; Carolina/Angélica/Lizeth/Leiver/Cindy in past
- [ ] Check `/en/contributors` copy parity
- [ ] `pnpm run biome:check && pnpm run astro:check && pnpm run test`

## Plan
Completes **PLAN_contributors_team_page_restructure** (10/10).


Made with [Cursor](https://cursor.com)