### PR TITLE
feat(community): sponsors page — current/past only, no PTD tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,6 @@
 | Blog Lifecycle | [Blog Content Lifecycle](docs/features/BLOG_CONTENT_LIFECYCLE.md) | End-to-end blog workflow |
 | Certificates | [Certificates](docs/features/CERTIFICATES.md) | Individual diploma pages, print/PDF, verify UX, fixtures |
 | Authors | [Authors](docs/features/AUTHORS.md) | Multi-author support, YAML schema, AuthorCard, JSON-LD |
-| Contributors | [Contributors](docs/features/CONTRIBUTORS.md) | Equipo directory — flat organizers + unified alumni |
 | Sponsors | [Sponsors](docs/features/SPONSORS.md) | Community partners — current/past (tiers on PTD only) |
 | Writing Voice | [Writing Voice Guide](docs/WRITING_VOICE_GUIDE.md) | Anti-AI-slop checklist, PTT voice, vocabulary blocklist |
 | Content QA | [Content QA Checklist](docs/features/CONTENT_QA_CHECKLIST.md) | Bilingual parity, orthography, SEO/AEO, automated gates |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
 | Blog Lifecycle | [Blog Content Lifecycle](docs/features/BLOG_CONTENT_LIFECYCLE.md) | End-to-end blog workflow |
 | Certificates | [Certificates](docs/features/CERTIFICATES.md) | Individual diploma pages, print/PDF, verify UX, fixtures |
 | Authors | [Authors](docs/features/AUTHORS.md) | Multi-author support, YAML schema, AuthorCard, JSON-LD |
+| Contributors | [Contributors](docs/features/CONTRIBUTORS.md) | Equipo directory — flat organizers + unified alumni |
+| Sponsors | [Sponsors](docs/features/SPONSORS.md) | Community partners — current/past (tiers on PTD only) |
 | Writing Voice | [Writing Voice Guide](docs/WRITING_VOICE_GUIDE.md) | Anti-AI-slop checklist, PTT voice, vocabulary blocklist |
 | Content QA | [Content QA Checklist](docs/features/CONTENT_QA_CHECKLIST.md) | Bilingual parity, orthography, SEO/AEO, automated gates |
 | Writing Craft | [Writing Craft Guide](docs/WRITING_CRAFT_GUIDE.md) | Narrative structure, fact verification, quote handling, refinement |

--- a/docs/INFORMATION_ARCHITECTURE.md
+++ b/docs/INFORMATION_ARCHITECTURE.md
@@ -52,8 +52,8 @@ match this IA, you are creating drift.
 | Allied Communities (stub) | `/communities` | `/es/communities` | static | `communities.astro` | `CommunitiesPage.astro` (full page craft lands in Tasks 71–72) | pending |
 | Contributors catalog | `/contributors` | `/es/contributors` | `contributors` | `contributors/index.astro` | `ContributorsCatalogPage.astro` | yes |
 | Contributor profile | `/contributors/{slug}` | `/es/contributors/{slug}` | `contributors` | `contributors/[slug].astro` | `ContributorProfilePage.astro` | per-slug `.md` |
-| Sponsors catalog | `/sponsors` | `/es/sponsors` | `sponsors` | `sponsors/index.astro` | `SponsorsCatalogPage.astro` (grouped by tier) | yes |
-| Sponsor profile | `/sponsors/{slug}` | `/es/sponsors/{slug}` | `sponsors` | `sponsors/[slug].astro` | `SponsorProfilePage.astro` | per-slug `.md` |
+| Sponsors catalog | `/sponsors` | `/en/sponsors` | `sponsors` | `sponsors/index.astro` | `SponsorsPage.astro` (current + past; no PTD tier headings) | yes |
+| ~~Sponsor profile~~ | not shipped | — | — | — | Future; cards link externally | n/a |
 | Channels | `/channels` | `/es/channels` | `channels` | `channels.astro` | `ChannelsPage.astro` | yes |
 | Press / Media kit | `/press` | `/es/press` | static | `press.astro` | `PressPage.astro` | yes |
 | Contact | `/contact` | `/es/contact` | form | `contact.astro` | `ContactPage.astro` | yes |

--- a/docs/features/SPONSORS.md
+++ b/docs/features/SPONSORS.md
@@ -1,0 +1,40 @@
+# Sponsors — Feature Guide
+
+Community partners directory at `/sponsors` (EN: `/en/sponsors`).
+
+## Page IA
+
+1. **Hero** — partnership framing + dual CTAs (`/sponsor-us`, `/contact`)
+2. **Why sponsor** — three concrete value props
+3. **Current partners** — flat grid of `status: active` (no PTD tier headings)
+4. **Past partners** — flat grid of `status: past`
+
+**Per-edition tiers** (diamond/gold/silver/bronze/community) belong on **Pereira Tech Day** edition pages via `sponsoredEditions` / `getEditionSponsors` — not on this catalog.
+
+## Content
+
+YAML in `src/content/sponsors/{slug}.yaml`:
+
+| Field | Notes |
+|-------|--------|
+| `status` | `active` \| `past` — drives community page sections |
+| `tier` | Kept for PTD; **not** shown as section headings on `/sponsors` |
+| `sponsoredEditions` | `{ year, tier }[]` for edition showcases |
+| `order` | Sort within current/past |
+
+## Components
+
+- `SponsorsPage.astro` — community catalog
+- `SponsorCard.astro` — `showTier={false}` on community page
+- `src/lib/sponsor.ts` — `getActiveSponsors` / `getPastSponsors` sort by order; `sortSponsors` still tier-aware for PTD
+
+## Adding a partner
+
+1. Add YAML + logos under `public/images/sponsors/`
+2. Set `status: active` or `past`
+3. Keep slug stable if referenced from PTD editions
+
+## Related
+
+- `/sponsor-us` inquiry form
+- `docs/SPONSORSHIP.md` — commercial tiers & process

--- a/src/components/cards/SponsorCard.astro
+++ b/src/components/cards/SponsorCard.astro
@@ -1,7 +1,6 @@
 ---
 /**
- * PTT v3.0.0 sponsor card — preview card for a `sponsors` collection entry.
- * Tier-aware: tier label, accent ring, light/dark logo variants.
+ * Sponsor card for community catalog and (optionally) tiered PTD contexts.
  */
 
 import type { CollectionEntry } from 'astro:content';
@@ -14,13 +13,23 @@ interface Props {
   loading?: 'lazy' | 'eager';
   /**
    * Overrides the sponsor's default tier. Used when a card is rendered in the
-   * context of a specific Pereira Tech Day edition, where the tier recorded on
-   * that edition wins over the sponsor's own.
+   * context of a specific Pereira Tech Day edition.
    */
   tier?: CollectionEntry<'sponsors'>['data']['tier'];
+  /** Community catalog hides PTD-style tier badges. */
+  showTier?: boolean;
+  /** Quieter treatment for past partners. */
+  muted?: boolean;
 }
 
-const { sponsor, lang, loading = 'lazy', tier: tierProp } = Astro.props;
+const {
+  sponsor,
+  lang,
+  loading = 'lazy',
+  tier: tierProp,
+  showTier = true,
+  muted = false,
+} = Astro.props;
 
 const tier = tierProp ?? sponsor.data.tier;
 const tierLabel: Record<typeof tier, { en: string; es: string }> = {
@@ -42,40 +51,51 @@ const sameLogo = logoLight === logoDark;
   href={sponsor.data.url}
   target="_blank"
   rel="noopener noreferrer"
-  class="group flex h-full min-w-0 flex-col rounded-2xl bg-ptt-bg-elevated shadow-sm ring-1 ring-ptt-border p-4 sm:p-6 transition hover:shadow-lg hover:ring-ptt-primary/30 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary"
+  class:list={[
+    'group flex h-full min-w-0 flex-col rounded-2xl p-4 sm:p-6 transition motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary',
+    muted
+      ? 'bg-ptt-bg-elevated/80 shadow-none ring-1 ring-ptt-border/70 hover:ring-ptt-border dark:bg-ptt-bg-dark/40'
+      : 'bg-ptt-bg-elevated shadow-sm ring-1 ring-ptt-border hover:shadow-lg hover:ring-ptt-primary/30',
+  ]}
 >
   <div class="flex flex-wrap items-start justify-between gap-3 sm:gap-4">
-    <div class="flex h-16 w-32 max-w-full min-w-0 items-center">
+    <div class="flex h-16 w-36 max-w-full min-w-0 items-center">
       {
         sameLogo ? (
-          <img decoding="async"
+          <img
+            decoding="async"
             src={logoLight}
             alt={logoAlt}
             width="160"
             height="64"
             loading={loading}
-            class="max-h-16 max-w-full object-contain" />
+            class="max-h-16 max-w-full object-contain"
+          />
         ) : (
           <>
-            <img decoding="async"
+            <img
+              decoding="async"
               src={logoLight}
               alt={logoAlt}
               width="160"
               height="64"
               loading={loading}
-              class="max-h-16 max-w-full object-contain dark:hidden" />
-            <img decoding="async"
+              class="max-h-16 max-w-full object-contain dark:hidden"
+            />
+            <img
+              decoding="async"
               src={logoDark}
               alt={logoAlt}
               width="160"
               height="64"
               loading={loading}
-              class="hidden max-h-16 max-w-full object-contain dark:block" />
+              class="hidden max-h-16 max-w-full object-contain dark:block"
+            />
           </>
         )
       }
     </div>
-    <Badge variant={tier}>{tierLabel[tier][lang]}</Badge>
+    {showTier && <Badge variant={tier}>{tierLabel[tier][lang]}</Badge>}
   </div>
   <h3 class="mt-4 text-lg font-semibold text-ptt group-hover:text-ptt-primary">
     {sponsor.data.name}

--- a/src/components/pages/SponsorsPage.astro
+++ b/src/components/pages/SponsorsPage.astro
@@ -1,7 +1,6 @@
 ---
 /**
- * PTT v3.0.0 sponsors directory page (shared between EN and ES).
- * Current sponsors prominently; past sponsors in a dedicated archive section.
+ * Community sponsors directory — Current + Past only (no PTD tier headings).
  */
 
 import SponsorCard from '@/components/cards/SponsorCard.astro';
@@ -26,97 +25,98 @@ const prefix = getUrlPrefix(lang);
 const currentSponsors = await getActiveSponsors();
 const pastSponsors = await getPastSponsors();
 
-type Tier = 'diamond' | 'gold' | 'silver' | 'bronze' | 'community';
-const tierOrder: Tier[] = ['diamond', 'gold', 'silver', 'bronze', 'community'];
-
-function groupByTier(sponsors: Awaited<ReturnType<typeof getActiveSponsors>>) {
-  return tierOrder
-    .map((tier) => ({
-      tier,
-      sponsors: sponsors.filter((s) => s.data.tier === tier),
-    }))
-    .filter((group) => group.sponsors.length > 0);
-}
-
-const currentByTier = groupByTier(currentSponsors);
-const pastByTier = groupByTier(pastSponsors);
-const totalCount = currentSponsors.length + pastSponsors.length;
-
 const breadcrumbs = [
   { label: sp.breadcrumbHome, href: `${prefix}/` },
   { label: sp.title },
 ];
+
+const whyItems = [sp.why.items.meetups, sp.why.items.ptd, sp.why.items.talent];
 ---
 
 <MainLayout lang={lang} title={sp.title} description={sp.description}>
-  <div class="bg-gradient-to-b from-ptt-primary-soft/50 to-ptt-bg dark:from-ptt-bg-elevated dark:to-ptt-bg">
-    <div class="main-container pt-12 sm:pt-16 pb-4">
+  <div class="relative overflow-hidden bg-ptt-bg">
+    <div
+      class="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--ptt-primary)_0%,_transparent_55%)] opacity-[0.07] dark:opacity-[0.12]"
+      aria-hidden="true"
+    >
+    </div>
+    <div class="main-container relative pt-12 sm:pt-16 pb-4">
       <Breadcrumbs items={breadcrumbs} />
     </div>
-    <div class="main-container pt-6 pb-12">
+    <div class="main-container relative pt-6 pb-14 sm:pb-16">
       <Eyebrow>{sp.eyebrow}</Eyebrow>
-      <h1 class="mt-3 text-4xl sm:text-5xl font-bold tracking-tight text-ptt">
+      <h1 class="mt-3 max-w-3xl text-4xl sm:text-5xl font-bold tracking-tight text-ptt">
         {sp.title}
       </h1>
-      <p class="mt-4 max-w-3xl text-lg text-ptt-secondary">
-        {sp.intro(totalCount)}
+      <p class="mt-4 max-w-2xl text-lg text-ptt-secondary">
+        {sp.intro(currentSponsors.length)}
       </p>
-      <a
-        href={`${prefix}/sponsor-us/`}
-        class="mt-6 inline-flex items-center gap-2 rounded-full bg-ptt-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-ptt-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark dark:hover:bg-ptt-primary-dark/90"
-      >
-        {sp.sponsorUsLabel}
-      </a>
+      <div class="mt-8 flex flex-wrap items-center gap-3">
+        <a
+          href={`${prefix}/sponsor-us/`}
+          class="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-ptt-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-ptt-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark dark:hover:bg-ptt-primary-dark/90"
+        >
+          {sp.sponsorUsLabel}
+        </a>
+        <a
+          href={`${prefix}/contact/`}
+          class="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-ptt-border bg-ptt-bg-elevated px-5 py-2.5 text-sm font-semibold text-ptt transition-colors hover:border-ptt-primary/40 hover:bg-ptt-primary-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:border-white/15 dark:bg-ptt-bg-dark dark:text-white dark:hover:bg-white/10"
+        >
+          {sp.contactLabel}
+        </a>
+      </div>
     </div>
   </div>
 
+  <Section surface="alt" spacing="lg" title={sp.why.title}>
+    <p class="mb-8 max-w-2xl text-ptt-secondary">{sp.why.intro}</p>
+    <ul class="grid list-none gap-6 sm:grid-cols-3">
+      {
+        whyItems.map((item) => (
+          <li class="rounded-2xl bg-ptt-bg-elevated p-5 ring-1 ring-ptt-border dark:bg-ptt-bg-dark/40">
+            <h3 class="text-base font-semibold text-ptt">{item.title}</h3>
+            <p class="mt-2 text-sm text-ptt-secondary">{item.body}</p>
+          </li>
+        ))
+      }
+    </ul>
+  </Section>
+
   {
-    currentByTier.length > 0 ? (
-      <Section surface="alt" spacing="lg" title={sp.currentTitle}>
-        <div class="space-y-16">
-          {currentByTier.map(({ tier, sponsors: group }) => (
-            <div>
-              <h2 class="mb-6 text-2xl font-bold tracking-tight text-ptt">
-                {sp.tiers[tier]}
-              </h2>
-              <ul class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none">
-                {group.map((sponsor) => (
-                  <li>
-                    <SponsorCard sponsor={sponsor} lang={lang} />
-                  </li>
-                ))}
-              </ul>
-            </div>
+    currentSponsors.length > 0 ? (
+      <Section spacing="lg" title={sp.currentTitle}>
+        <p class="mb-10 max-w-2xl text-ptt-secondary">{sp.currentIntro}</p>
+        <ul class="grid list-none gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {currentSponsors.map((sponsor, index) => (
+            <li>
+              <SponsorCard
+                sponsor={sponsor}
+                lang={lang}
+                showTier={false}
+                loading={index < 3 ? 'eager' : 'lazy'}
+              />
+            </li>
           ))}
-        </div>
+        </ul>
       </Section>
     ) : (
-      <Section surface="alt">
+      <Section>
         <EmptyState title={sp.emptyTitle} description={sp.emptyDesc} />
       </Section>
     )
   }
 
   {
-    pastByTier.length > 0 && (
-      <Section spacing="lg" title={sp.pastTitle}>
+    pastSponsors.length > 0 && (
+      <Section surface="alt" spacing="lg" title={sp.pastTitle}>
         <p class="mb-10 max-w-3xl text-ptt-secondary">{sp.pastIntro}</p>
-        <div class="space-y-12">
-          {pastByTier.map(({ tier, sponsors: group }) => (
-            <div>
-              <h2 class="mb-6 text-xl font-semibold tracking-tight text-ptt-secondary">
-                {sp.tiers[tier]}
-              </h2>
-              <ul class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 list-none">
-                {group.map((sponsor) => (
-                  <li>
-                    <SponsorCard sponsor={sponsor} lang={lang} />
-                  </li>
-                ))}
-              </ul>
-            </div>
+        <ul class="grid list-none gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {pastSponsors.map((sponsor) => (
+            <li class="opacity-90 transition-opacity motion-reduce:transition-none hover:opacity-100">
+              <SponsorCard sponsor={sponsor} lang={lang} showTier={false} muted />
+            </li>
           ))}
-        </div>
+        </ul>
       </Section>
     )
   }

--- a/src/content/sponsors/ase-utp.yaml
+++ b/src/content/sponsors/ase-utp.yaml
@@ -5,11 +5,11 @@ logo:
   alt: Asociación Egresados Sistemas UTP logo
 url: "https://egresados.utp.edu.co/"
 description:
-  en: Asociación de Egresados de Sistemas, Universidad Tecnológica de Pereira. Sponsor of Pereira Tech Day 2024 (gold tier).
-  es: Asociación de Egresados de Sistemas de la Universidad Tecnológica de Pereira. Patrocinador de Pereira Tech Day 2024 (oro).
+  en: Asociación de Egresados de Sistemas, Universidad Tecnológica de Pereira. Active community partner of Pereira Tech Talks — connecting alumni talent with meetups and Pereira Tech Day.
+  es: Asociación de Egresados de Sistemas de la Universidad Tecnológica de Pereira. Aliado activo de Pereira Tech Talks — conecta talento egresado con los meetups y Pereira Tech Day.
 tier: gold
 sponsoredEditions:
   - year: 2024
     tier: gold
-status: past
-order: 3
+status: active
+order: 2

--- a/src/content/sponsors/dailybot.yaml
+++ b/src/content/sponsors/dailybot.yaml
@@ -5,11 +5,11 @@ logo:
   alt: DailyBot logo
 url: "https://www.dailybot.com/"
 description:
-  en: AI assistants for high-performing teams. Sponsor of Pereira Tech Day 2024 (silver tier).
-  es: Asistentes de IA para equipos de alto desempeño. Patrocinador de Pereira Tech Day 2024 (plata).
+  en: AI assistants for high-performing teams. Active community partner of Pereira Tech Talks — supporting meetups and the annual Pereira Tech Day stage.
+  es: Asistentes de IA para equipos de alto desempeño. Aliado activo de Pereira Tech Talks — apoya los meetups y el escenario de Pereira Tech Day.
 tier: silver
 sponsoredEditions:
   - year: 2024
     tier: silver
 status: active
-order: 4
+order: 3

--- a/src/content/sponsors/veritran.yaml
+++ b/src/content/sponsors/veritran.yaml
@@ -5,11 +5,11 @@ logo:
   alt: Veritran logo
 url: "https://veritran.com/"
 description:
-  en: Low-code technology company for digital banking and financial applications. Confirmed gold sponsor of Pereira Tech Day 2026 — supporting the next edition of the community's flagship conference.
-  es: Compañía de tecnología low-code para banca digital y aplicaciones financieras. Patrocinador oro confirmado de Pereira Tech Day 2026 — apoya la próxima edición de la conferencia insignia de la comunidad.
+  en: Low-code technology for digital banking and financial applications. Active community partner of Pereira Tech Talks and gold sponsor of Pereira Tech Day 2026.
+  es: Tecnología low-code para banca digital y aplicaciones financieras. Aliado activo de Pereira Tech Talks y patrocinador oro de Pereira Tech Day 2026.
 tier: gold
 sponsoredEditions:
   - year: 2026
     tier: gold
 status: active
-order: 4
+order: 1

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -20,6 +20,15 @@ const sortByTierThenOrder = (a: Sponsor, b: Sponsor): number => {
 export const sortSponsors = (sponsors: Sponsor[]): Sponsor[] =>
   [...sponsors].sort(sortByTierThenOrder);
 
+/** Community catalog sort — order then name (no tier grouping). */
+export const sortSponsorsByOrder = (sponsors: Sponsor[]): Sponsor[] =>
+  [...sponsors].sort((a, b) => {
+    const oa = a.data.order ?? 0;
+    const ob = b.data.order ?? 0;
+    if (oa !== ob) return oa - ob;
+    return a.data.name.localeCompare(b.data.name);
+  });
+
 export const filterSponsorsByStatus = (
   sponsors: Sponsor[],
   status: Sponsor['data']['status']
@@ -32,12 +41,12 @@ export const getSponsors = async (): Promise<Sponsor[]> => {
 
 export const getActiveSponsors = async (): Promise<Sponsor[]> => {
   const all = await getSponsors();
-  return filterSponsorsByStatus(all, 'active');
+  return sortSponsorsByOrder(filterSponsorsByStatus(all, 'active'));
 };
 
 export const getPastSponsors = async (): Promise<Sponsor[]> => {
   const all = await getSponsors();
-  return filterSponsorsByStatus(all, 'past');
+  return sortSponsorsByOrder(filterSponsorsByStatus(all, 'past'));
 };
 
 export const getSponsorsByTier = async (

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -526,18 +526,40 @@ Browse the catalog, attend the next meetup, or get in touch if you want to speak
   sponsorsPage: {
     title: 'Sponsors',
     description:
-      'Meet the companies and community partners that make Pereira Tech Talks meetups, Pereira Tech Day, and community programs possible.',
+      'Current and past partners of Pereira Tech Talks — companies and organizations that sustain meetups, Pereira Tech Day, and community programs in Pereira.',
     eyebrow: 'Partners',
     intro: (count) =>
-      `${count} partners sustaining the community with venues, food, scholarships, and mentorship.`,
-    currentTitle: 'Current sponsors',
-    pastTitle: 'Past sponsors',
+      `${count} active partners help with venues, logistics, and the stage. Per-edition sponsorship tiers live on each Pereira Tech Day page — not here.`,
+    currentTitle: 'Current partners',
+    currentIntro:
+      'Who stands with Pereira Tech Talks today — monthly meetups and the annual conference.',
+    pastTitle: 'Past partners',
     pastIntro:
-      'Organizations that supported previous editions. We are grateful for every partnership that helped the community grow.',
-    sponsorUsLabel: 'Sponsor us: request the deck',
+      'Organizations that supported earlier chapters. Every partnership left a mark on the community.',
+    sponsorUsLabel: 'Become a sponsor',
+    contactLabel: 'Contact us',
     emptyTitle: 'No sponsors yet',
     emptyDesc: 'Want to support the community? Reach out.',
     breadcrumbHome: 'Home',
+    why: {
+      title: 'Why sponsor',
+      intro:
+        'We are not selling a logo on a website. We build stages where local talent meets companies that want to hire, teach, and learn in Pereira.',
+      items: {
+        meetups: {
+          title: 'Real meetups',
+          body: 'Venue, snacks, and monthly continuity — the community needs partners who make each talk night possible.',
+        },
+        ptd: {
+          title: 'Pereira Tech Day',
+          body: 'The annual conference with per-edition packages (gold, silver, and more). Those tier menus live on each year’s page, not here.',
+        },
+        talent: {
+          title: 'Local talent',
+          body: 'Access to engineers, speakers, and students across Risaralda who already build in public.',
+        },
+      },
+    },
     tiers: {
       diamond: 'Diamond sponsors',
       gold: 'Gold sponsors',

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -527,18 +527,40 @@ Explora el catálogo, asiste al próximo meetup o escríbenos si quieres ser pon
   sponsorsPage: {
     title: 'Patrocinadores',
     description:
-      'Conoce a las empresas y aliados comunitarios que hacen posibles los meetups, Pereira Tech Day y los programas de la comunidad.',
+      'Aliados actuales y anteriores de Pereira Tech Talks — empresas y organizaciones que sostienen meetups, Pereira Tech Day y los programas de la comunidad en Pereira.',
     eyebrow: 'Aliados',
     intro: (count) =>
-      `${count} aliados que sostienen la comunidad con venues, comida, becas y mentoría.`,
-    currentTitle: 'Patrocinadores actuales',
-    pastTitle: 'Patrocinadores anteriores',
+      `${count} aliados activos sostienen venues, logística y escenario. Las categorías de patrocinio por edición viven en cada Pereira Tech Day.`,
+    currentTitle: 'Aliados actuales',
+    currentIntro:
+      'Quienes acompañan a Pereira Tech Talks hoy — meetups mensuales y la conferencia anual.',
+    pastTitle: 'Aliados anteriores',
     pastIntro:
-      'Organizaciones que apoyaron ediciones previas. Agradecemos cada alianza que ayudó a la comunidad a crecer.',
-    sponsorUsLabel: 'Patrocínanos: solicita el deck',
+      'Organizaciones que apoyaron capítulos previos. Cada alianza dejó huella en la comunidad.',
+    sponsorUsLabel: 'Quiero patrocinar',
+    contactLabel: 'Escríbenos',
     emptyTitle: 'Aún no hay patrocinadores registrados',
     emptyDesc: '¿Te interesa apoyar la comunidad? Escríbenos.',
     breadcrumbHome: 'Inicio',
+    why: {
+      title: 'Por qué patrocinar',
+      intro:
+        'No vendemos un logo en una web. Construimos escenarios donde el talento local se encuentra con empresas que quieren contratar, enseñar y aprender en Pereira.',
+      items: {
+        meetups: {
+          title: 'Meetups reales',
+          body: 'Venue, snacks y continuidad mensual — la comunidad necesita aliados que hagan posible cada noche de charlas.',
+        },
+        ptd: {
+          title: 'Pereira Tech Day',
+          body: 'La conferencia anual con paquetes por edición (oro, plata, etc.). Ese menú de categorías vive en la página de cada año, no aquí.',
+        },
+        talent: {
+          title: 'Talento local',
+          body: 'Acceso a ingenieras e ingenieros, speakers y estudiantes de Risaralda que ya están construyendo en público.',
+        },
+      },
+    },
     tiers: {
       diamond: 'Patrocinadores diamante',
       gold: 'Patrocinadores oro',

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -336,12 +336,24 @@ export interface SiteTranslations {
     eyebrow: string;
     intro: (count: number) => string;
     currentTitle: string;
+    currentIntro: string;
     pastTitle: string;
     pastIntro: string;
     sponsorUsLabel: string;
+    contactLabel: string;
     emptyTitle: string;
     emptyDesc: string;
     breadcrumbHome: string;
+    why: {
+      title: string;
+      intro: string;
+      items: {
+        meetups: { title: string; body: string };
+        ptd: { title: string; body: string };
+        talent: { title: string; body: string };
+      };
+    };
+    /** Kept for PTD / legacy copy; community `/sponsors` page does not render these. */
     tiers: {
       diamond: string;
       gold: string;

--- a/src/pages/en/sponsors/index.md.ts
+++ b/src/pages/en/sponsors/index.md.ts
@@ -4,26 +4,37 @@ import {
   resolveI18n,
   serializeGenericToMarkdown,
 } from '@/lib/markdown-for-agents';
-import { getSponsors } from '@/lib/sponsor';
+import { getActiveSponsors, getPastSponsors } from '@/lib/sponsor';
 
 const SITE_URL = 'https://pereiratechtalks.org';
 
 export const GET: APIRoute = async () => {
   const lang = 'en';
-  const sponsors = await getSponsors();
-  const lines = sponsors.map((s) => {
-    const description = resolveI18n(s.data.description, lang);
-    return `- [${s.data.name}](${s.data.url}) (${s.data.tier}, ${s.data.status}) — ${description}`;
-  });
+  const current = await getActiveSponsors();
+  const past = await getPastSponsors();
+
+  const toLines = (
+    list: Awaited<ReturnType<typeof getActiveSponsors>>
+  ): string[] =>
+    list.map((s) => {
+      const description = resolveI18n(s.data.description, lang);
+      return `- [${s.data.name}](${s.data.url}) — ${description}`;
+    });
 
   const markdown = serializeGenericToMarkdown({
     title: 'Sponsors — Pereira Tech Talks',
     description:
-      'Companies and organizations that have supported Pereira Tech Talks meetups, Speaker School, La Biblioteca del Mañana, and Pereira Tech Day editions.',
+      'Current and past partners of Pereira Tech Talks. Per-edition tiers (gold, silver, etc.) live on each Pereira Tech Day page — not on this community directory.',
     lang,
     canonical: `${SITE_URL}/en/sponsors`,
-    metadata: [['Total sponsors', String(sponsors.length)]],
-    sections: [{ heading: 'All sponsors', lines }],
+    metadata: [
+      ['Current partners', String(current.length)],
+      ['Past partners', String(past.length)],
+    ],
+    sections: [
+      { heading: 'Current partners', lines: toLines(current) },
+      { heading: 'Past partners', lines: toLines(past) },
+    ],
   });
 
   return new Response(markdown, {

--- a/src/pages/sponsors/index.md.ts
+++ b/src/pages/sponsors/index.md.ts
@@ -4,26 +4,37 @@ import {
   resolveI18n,
   serializeGenericToMarkdown,
 } from '@/lib/markdown-for-agents';
-import { getSponsors } from '@/lib/sponsor';
+import { getActiveSponsors, getPastSponsors } from '@/lib/sponsor';
 
 const SITE_URL = 'https://pereiratechtalks.org';
 
 export const GET: APIRoute = async () => {
   const lang = 'es';
-  const sponsors = await getSponsors();
-  const lines = sponsors.map((s) => {
-    const description = resolveI18n(s.data.description, lang);
-    return `- [${s.data.name}](${s.data.url}) (${s.data.tier}, ${s.data.status}) — ${description}`;
-  });
+  const current = await getActiveSponsors();
+  const past = await getPastSponsors();
+
+  const toLines = (
+    list: Awaited<ReturnType<typeof getActiveSponsors>>
+  ): string[] =>
+    list.map((s) => {
+      const description = resolveI18n(s.data.description, lang);
+      return `- [${s.data.name}](${s.data.url}) — ${description}`;
+    });
 
   const markdown = serializeGenericToMarkdown({
     title: 'Patrocinadores — Pereira Tech Talks',
     description:
-      'Empresas y organizaciones que han apoyado los meetups, la Escuela de Ponentes, La Biblioteca del Mañana y las ediciones de Pereira Tech Day.',
+      'Aliados actuales y anteriores de Pereira Tech Talks. Las categorías por edición (oro, plata, etc.) viven en cada Pereira Tech Day, no en este directorio comunitario.',
     lang,
     canonical: `${SITE_URL}/sponsors`,
-    metadata: [['Total de patrocinadores', String(sponsors.length)]],
-    sections: [{ heading: 'Todos los patrocinadores', lines }],
+    metadata: [
+      ['Aliados actuales', String(current.length)],
+      ['Aliados anteriores', String(past.length)],
+    ],
+    sections: [
+      { heading: 'Aliados actuales', lines: toLines(current) },
+      { heading: 'Aliados anteriores', lines: toLines(past) },
+    ],
   });
 
   return new Response(markdown, {

--- a/tests/unit/lib/sponsor.test.ts
+++ b/tests/unit/lib/sponsor.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Sponsor } from '@/lib/sponsor';
-import { filterSponsorsByStatus, sortSponsors } from '@/lib/sponsor';
+import {
+  filterSponsorsByStatus,
+  sortSponsors,
+  sortSponsorsByOrder,
+} from '@/lib/sponsor';
 
 const makeSponsor = (
   id: string,
@@ -24,7 +28,7 @@ const makeSponsor = (
   }) as Sponsor;
 
 describe('sponsor helpers', () => {
-  it('sorts sponsors by tier then order', () => {
+  it('sorts sponsors by tier then order (PTD path)', () => {
     const sponsors = sortSponsors([
       makeSponsor('silver', { tier: 'silver', order: 1 }),
       makeSponsor('gold', { tier: 'gold', order: 5 }),
@@ -32,6 +36,16 @@ describe('sponsor helpers', () => {
     ]);
 
     expect(sponsors.map((s) => s.id)).toEqual(['gold-first', 'gold', 'silver']);
+  });
+
+  it('sorts community catalog by order then name', () => {
+    const sponsors = sortSponsorsByOrder([
+      makeSponsor('zeta', { order: 2, name: 'Zeta', tier: 'diamond' }),
+      makeSponsor('alpha', { order: 1, name: 'Alpha', tier: 'bronze' }),
+      makeSponsor('beta', { order: 1, name: 'Beta', tier: 'diamond' }),
+    ]);
+
+    expect(sponsors.map((s) => s.id)).toEqual(['alpha', 'beta', 'zeta']);
   });
 
   it('filters sponsors by status without overlap', () => {


### PR DESCRIPTION
## Summary
- Community `/sponsors` shows only **Current** and **Past** partners — no Diamond/Gold/Silver section headings (those stay on Pereira Tech Day pages).
- Current roster: **Veritran**, **ASE-UTP**, **DailyBot**; everyone else → past.
- Stronger hero (dual CTAs), “Why sponsor” strip, cards without tier badges, i18n, tests, and `docs/features/SPONSORS.md`.

## Test plan
- [ ] `/sponsors` — exactly three current partners; no Oro/Plata/Diamante headings
- [ ] `/en/sponsors` parity
- [ ] Spot-check a PTD edition still shows tiered sponsorship packages
- [ ] `pnpm run biome:check && pnpm run astro:check && pnpm run test`

## Plan
Completes **PLAN_sponsors_page_current_past_restructure** (10/10).


Made with [Cursor](https://cursor.com)