### PR TITLE
fix(forms): Dailybot-only intakes (remove Google Forms fallback)

### DIFF
--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -11,7 +11,7 @@ Copy `docker/local/pertechtalks/.env.example` → `.env` inside the same directo
 | Variable | Required | Notes |
 |----------|----------|-------|
 | `DAILYBOT_API_KEY` | Yes (Functions) | Personal API key from Dailybot user settings. Server-only. See [FORMS.md](./features/FORMS.md). |
-| `PUBLIC_CONTACT_API_ENDPOINT` | Recommended | e.g. `/api/contact` so Svelte forms hit the Pages Function |
+| `PUBLIC_CONTACT_API_ENDPOINT` | Optional | Defaults to `/api/contact` in code. Override only if the Function is mounted elsewhere. |
 | `RESEND_API_KEY` | Optional | Submitter ack after Dailybot success |
 | `CONTACT_FROM_EMAIL` | Optional with Resend | Verified sender |
 | `CONTACT_RATE_LIMIT` / `CONTACT_RATE_WINDOW_MS` | Optional | Defaults 8 / 600000 |

--- a/docs/features/CONTACT_FORM.md
+++ b/docs/features/CONTACT_FORM.md
@@ -19,11 +19,8 @@ auto-ack may run after a successful Dailybot response.
 Contact topics (UI): `general` · `collaboration` · `the-library-of-tomorrow` ·
 `press` · `other`. CFS / sponsorship / conduct use dedicated pages.
 
-### Google Forms fallback
-
-If `PUBLIC_CONTACT_API_ENDPOINT` is empty, the general `ContactForm` may POST to
-Google Forms (`src/lib/constances.ts`). Structured Dailybot intakes require the
-Functions endpoint.
+All intakes POST JSON to `CONTACT_FORM.apiEndpoint` (default `/api/contact`).
+There is **no** Google Forms fallback.
 
 ### Client modules
 

--- a/docs/features/FORMS.md
+++ b/docs/features/FORMS.md
@@ -24,14 +24,15 @@ Canonical UUIDs and choice lookups live in `functions/api/_dailybot.ts`.
 | Community calendar | `CalendarIntakeForm.svelte` | `/calendar#calendar-intake` | `calendar` | PTT Community Calendar |
 | Code of Conduct | `ConductReportForm.svelte` | `/conduct#conduct-report-form` | `conduct` | PTT Code of Conduct |
 
-Newsletter signup remains on Google Forms (out of scope for this pipeline).
+Newsletter signup is disabled in the UI and has **no** Google Forms (or other)
+backend until a Dailybot form is added for it.
 
 ## Environment
 
 | Variable | Where | Notes |
 |----------|-------|-------|
 | `DAILYBOT_API_KEY` | Cloudflare / local Functions only | **Never** `PUBLIC_*`. Header `X-API-KEY`. |
-| `PUBLIC_CONTACT_API_ENDPOINT` | Build | Usually `/api/contact`. Empty → ContactForm Google Forms fallback only. |
+| `PUBLIC_CONTACT_API_ENDPOINT` | Build | Optional override. Defaults to `/api/contact` in `CONTACT_FORM`. |
 | `RESEND_API_KEY` + `CONTACT_FROM_EMAIL` | Optional | Submitter ack after Dailybot success |
 | `CONTACT_TO_*` | Optional | Legacy org-mirror inboxes if Resend mirror is enabled |
 | `CONTACT_RATE_LIMIT` / `CONTACT_RATE_WINDOW_MS` | Optional | Default 8 / 600000 |
@@ -71,7 +72,7 @@ This org’s Dailybot forms use **choice value === label** (e.g. `"General"`).
 Server helpers map site slugs (`general`, `lightning`, `gold`) → labels via
 `lookupChoice` in `_dailybot.ts`. Do not invent a parallel slugify POST contract.
 
-Booleans send Dailybot labels `Yes` / `No`.
+Booleans send JSON `true` / `false` (Dailybot `boolean` question type).
 
 ## Form UUIDs
 

--- a/functions/api/_dailybot.ts
+++ b/functions/api/_dailybot.ts
@@ -221,13 +221,18 @@ export const CONTRIBUTION_TYPE_VALUES = buildChoiceLookup([
   { aliases: ['Unsure', 'unsure'] },
 ]);
 
-/** Boolean DailyBot questions — probe confirmed labels may vary; send Yes/No. */
-export function booleanToDailyBot(value: boolean | string | undefined): string {
-  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+/**
+ * Boolean Dailybot questions require JSON `true` / `false` (not "Yes"/"No").
+ * Verified against PTT CFS + CoC forms (2026-08 audit).
+ */
+export function booleanToDailyBot(
+  value: boolean | string | undefined
+): boolean {
+  if (typeof value === 'boolean') return value;
   const n = normalizeLabel(String(value ?? ''));
-  if (['yes', 'true', '1', 'si', 'sí'].includes(n)) return 'Yes';
-  if (['no', 'false', '0'].includes(n)) return 'No';
-  return 'No';
+  if (['yes', 'true', '1', 'si', 'sí'].includes(n)) return true;
+  if (['no', 'false', '0'].includes(n)) return false;
+  return false;
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -348,7 +348,7 @@ function buildContent(
   const missing = requireNonEmpty(fields, ['incidentDescription']);
   if (missing) return missing;
   const anonymous = flags.anonymous;
-  const content: Record<string, string> = {
+  const content: Record<string, string | boolean> = {
     [CONDUCT_Q.INCIDENT]: fields.incidentDescription,
     [CONDUCT_Q.WHEN]: fields.incidentDate || '',
     [CONDUCT_Q.PEOPLE]: fields.peopleInvolved || '',

--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -148,7 +148,7 @@ function resolveFormType(data: Record<string, unknown>): FormType {
 interface ContentBuildResult {
   ok: true;
   formUuid: string;
-  content: Record<string, string>;
+  content: Record<string, string | boolean>;
   ackTopic: string;
 }
 

--- a/src/components/blog/NewsletterForm.svelte
+++ b/src/components/blog/NewsletterForm.svelte
@@ -6,8 +6,8 @@ import { getTranslations } from '@/lib/translations';
 const STORAGE_KEY = 'newsletter-subscribed';
 
 export let lang = 'es';
-export let formUrl = '';
-export let entries = { email: '' };
+/** Reserved for a future API path. No Google Forms backend. */
+export let apiEndpoint = '';
 
 $: t = getTranslations(lang);
 
@@ -15,6 +15,7 @@ $: t = getTranslations(lang);
 let formState = 'idle';
 let email = '';
 let emailError = '';
+let submitError = '';
 let website = '';
 let successRef;
 
@@ -30,6 +31,7 @@ function validateEmail(value) {
 
 async function handleSubmit() {
   emailError = '';
+  submitError = '';
 
   if (website.trim()) {
     // Honeypot — pretend success
@@ -42,30 +44,28 @@ async function handleSubmit() {
     return;
   }
 
+  if (!apiEndpoint) {
+    submitError = t.contactPage.submitError;
+    return;
+  }
+
   formState = 'submitting';
 
   try {
-    const formData = new FormData();
-    formData.append(entries.email, email);
-
-    await fetch(formUrl, {
+    const response = await fetch(apiEndpoint, {
       method: 'POST',
-      mode: 'no-cors',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams(formData),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, lang, website }),
     });
+    if (!response.ok) throw new Error('fail');
 
     localStorage.setItem(STORAGE_KEY, 'true');
     formState = 'success';
     trackEvent(EVENTS.NEWSLETTER_SUBSCRIBE);
     setTimeout(() => successRef?.focus(), 100);
   } catch {
-    // With no-cors, fetch only throws on network errors
-    // Still show success since we can't confirm either way
-    localStorage.setItem(STORAGE_KEY, 'true');
-    formState = 'success';
-    trackEvent(EVENTS.NEWSLETTER_SUBSCRIBE);
-    setTimeout(() => successRef?.focus(), 100);
+    submitError = t.contactPage.submitError;
+    formState = 'idle';
   }
 }
 </script>
@@ -152,6 +152,11 @@ async function handleSubmit() {
         {#if emailError}
           <p id="newsletter-email-error" class="mt-1 text-sm text-ptt-danger" aria-live="polite">
             {emailError}
+          </p>
+        {/if}
+        {#if submitError}
+          <p class="mt-1 text-sm text-ptt-danger" role="alert">
+            {submitError}
           </p>
         {/if}
       </div>

--- a/src/components/contact/CalendarIntakeForm.svelte
+++ b/src/components/contact/CalendarIntakeForm.svelte
@@ -5,7 +5,7 @@ import { focusFirstInvalidField } from '@/lib/form-ui';
 import { getTranslations } from '@/lib/translations';
 
 export let lang = 'es';
-export let apiEndpoint = '';
+export let apiEndpoint = '/api/contact';
 
 $: t = getTranslations(lang);
 $: f = t.calendarForm;

--- a/src/components/contact/ConductReportForm.svelte
+++ b/src/components/contact/ConductReportForm.svelte
@@ -5,7 +5,7 @@ import { focusFirstInvalidField } from '@/lib/form-ui';
 import { getTranslations } from '@/lib/translations';
 
 export let lang = 'es';
-export let apiEndpoint = '';
+export let apiEndpoint = '/api/contact';
 
 $: t = getTranslations(lang);
 $: f = t.conductForm;

--- a/src/components/contact/ContactForm.svelte
+++ b/src/components/contact/ContactForm.svelte
@@ -15,18 +15,10 @@ import { getTranslations } from '@/lib/translations';
 export let lang = 'es';
 /**
  * Cloudflare Pages Function endpoint (e.g. `/api/contact`) that submits to
- * Dailybot (optional Resend ack server-side). When empty, falls back to the
- * Google Forms direct POST configured in `entries` / `formUrl`.
+ * Dailybot Forms (optional Resend ack server-side). Required — no third-party
+ * form fallback.
  */
-export let apiEndpoint = '';
-export let formUrl = '';
-export let entries = {
-  name: '',
-  email: '',
-  reason: '',
-  subject: '',
-  message: '',
-};
+export let apiEndpoint = '/api/contact';
 
 $: t = getTranslations(lang);
 
@@ -161,22 +153,6 @@ async function submitToApi(endpoint) {
   }
 }
 
-async function submitToGoogleForms() {
-  const formData = new FormData();
-  formData.append(entries.name, name);
-  formData.append(entries.email, email);
-  formData.append(entries.reason, reason);
-  formData.append(entries.subject, subject);
-  formData.append(entries.message, message);
-
-  await fetch(formUrl, {
-    method: 'POST',
-    mode: 'no-cors',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams(formData),
-  });
-}
-
 async function handleSubmit() {
   submitError = '';
 
@@ -186,32 +162,24 @@ async function handleSubmit() {
     focusInvalid();
     return;
   }
+
+  if (!apiEndpoint) {
+    submitError = t.contactPage.submitError;
+    trackEvent(EVENTS.CONTACT_FORM_ERROR, { reason: 'no_backend_configured' });
+    return;
+  }
+
   formState = 'submitting';
 
   try {
-    if (apiEndpoint) {
-      await submitToApi(apiEndpoint);
-    } else if (formUrl) {
-      await submitToGoogleForms();
-    } else {
-      throw new Error('no_backend_configured');
-    }
-
+    await submitToApi(apiEndpoint);
     formState = 'success';
     trackEvent(EVENTS.CONTACT_FORM_SUBMIT, { reason: reason || 'unspecified' });
     setTimeout(() => successRef?.focus(), 100);
-  } catch (error) {
-    if (apiEndpoint) {
-      submitError = t.contactPage.submitError;
-      formState = 'idle';
-      trackEvent(EVENTS.CONTACT_FORM_ERROR, { reason: 'submit_failed' });
-      return;
-    }
-    // Google Forms uses no-cors so fetch only throws on hard network errors;
-    // treat as success since we cannot confirm either way.
-    formState = 'success';
-    trackEvent(EVENTS.CONTACT_FORM_SUBMIT, { reason: reason || 'unspecified' });
-    setTimeout(() => successRef?.focus(), 100);
+  } catch {
+    submitError = t.contactPage.submitError;
+    formState = 'idle';
+    trackEvent(EVENTS.CONTACT_FORM_ERROR, { reason: 'submit_failed' });
   }
 }
 

--- a/src/components/contact/SpeakerSchoolForm.svelte
+++ b/src/components/contact/SpeakerSchoolForm.svelte
@@ -5,7 +5,7 @@ import { focusFirstInvalidField } from '@/lib/form-ui';
 import { getTranslations } from '@/lib/translations';
 
 export let lang = 'es';
-export let apiEndpoint = '';
+export let apiEndpoint = '/api/contact';
 
 $: t = getTranslations(lang);
 $: f = t.speakerSchoolForm;

--- a/src/components/contact/SpeakersApplicationForm.svelte
+++ b/src/components/contact/SpeakersApplicationForm.svelte
@@ -5,7 +5,7 @@ import { focusFirstInvalidField } from '@/lib/form-ui';
 import { getTranslations } from '@/lib/translations';
 
 export let lang = 'es';
-export let apiEndpoint = '';
+export let apiEndpoint = '/api/contact';
 
 $: t = getTranslations(lang);
 $: f = t.cfsForm;

--- a/src/components/contact/SponsorInquiryForm.svelte
+++ b/src/components/contact/SponsorInquiryForm.svelte
@@ -5,7 +5,7 @@ import { focusFirstInvalidField } from '@/lib/form-ui';
 import { getTranslations } from '@/lib/translations';
 
 export let lang = 'es';
-export let apiEndpoint = '';
+export let apiEndpoint = '/api/contact';
 
 $: t = getTranslations(lang);
 $: f = t.sponsorForm;

--- a/src/components/pages/ContactPage.astro
+++ b/src/components/pages/ContactPage.astro
@@ -101,27 +101,11 @@ const quickLinks = t.contactPage.quickLinks.map((link) => ({
           {t.contactPage.formTitle}
         </h2>
         <p class="mb-8 text-ptt-secondary">{t.contactPage.formNote}</p>
-        {
-          CONTACT_FORM.apiEndpoint || CONTACT_FORM.googleForms.formUrl ? (
-            <ContactForm
-              client:visible
-              lang={lang}
-              apiEndpoint={CONTACT_FORM.apiEndpoint}
-              formUrl={CONTACT_FORM.googleForms.formUrl}
-              entries={CONTACT_FORM.googleForms.entries}
-            />
-          ) : (
-            <div class="rounded-2xl border border-ptt-border bg-ptt-bg-elevated p-8 text-center">
-              <p class="text-ptt-secondary mb-4">{t.contactPage.fallbackMessage}</p>
-              <a
-                href="mailto:pereiratechtalks@gmail.com"
-                class="font-semibold text-ptt-primary dark:text-ptt-primary-dark hover:underline"
-              >
-                {t.contactPage.fallbackEmailText} pereiratechtalks@gmail.com
-              </a>
-            </div>
-          )
-        }
+        <ContactForm
+          client:visible
+          lang={lang}
+          apiEndpoint={CONTACT_FORM.apiEndpoint}
+        />
       </div>
 
       <aside class="space-y-8">

--- a/src/lib/constances.ts
+++ b/src/lib/constances.ts
@@ -46,47 +46,24 @@ export const ANALYTICS = {
   },
 } as const;
 
-// Newsletter configuration — Google Forms direct POST
+/**
+ * Newsletter signup — currently disabled in UI (BlogPostPage).
+ * No Google Forms backend. Re-enable only with a Dailybot (or other) API path.
+ */
 export const NEWSLETTER = {
-  googleForms: {
-    formUrl:
-      'https://docs.google.com/forms/d/e/1FAIpQLSedegaN0_5eZWLIuizdKPCV1pAUm8vTatHo_ny07IXd8_xIfw/formResponse',
-    entries: {
-      email: 'entry.903587259',
-    },
-  },
+  apiEndpoint: '',
 } as const;
 
 /**
- * Contact form configuration.
+ * Community intake forms → Cloudflare Pages Function → Dailybot Forms.
  *
- * Two backends are supported:
- *
- * 1. **Cloudflare Pages Function + Resend (preferred for production).**
- *    Set `PUBLIC_CONTACT_API_ENDPOINT` (e.g. `/api/contact`) and configure
- *    the server-side `RESEND_API_KEY`, `CONTACT_TO_EMAIL`, and
- *    `CONTACT_FROM_EMAIL` secrets on the Cloudflare Pages project.
- *    The Svelte form POSTs a JSON payload that `functions/api/contact.ts`
- *    validates, spam-checks, and forwards via Resend.
- *
- * 2. **Google Forms fallback (legacy / static-only deployments).** When
- *    `PUBLIC_CONTACT_API_ENDPOINT` is empty, the Svelte form posts the
- *    submission directly to the Google Forms endpoint below using the
- *    same entry IDs configured in Google Forms.
- *
- * Both flows can coexist — the env-driven endpoint always wins.
+ * Default endpoint is `/api/contact` so production never silently falls back
+ * to a third-party form host. Override with `PUBLIC_CONTACT_API_ENDPOINT` when
+ * needed. Server secrets: `DAILYBOT_API_KEY` (required); optional Resend ack
+ * via `RESEND_API_KEY` + `CONTACT_FROM_EMAIL`.
  */
 export const CONTACT_FORM = {
-  apiEndpoint: (import.meta.env.PUBLIC_CONTACT_API_ENDPOINT || '').trim(),
-  googleForms: {
-    formUrl:
-      'https://docs.google.com/forms/d/e/1FAIpQLScuGSujpXLKF5eS4Z_6ZGAYf6j1iPrOIHwtJ-3i1_7MGk466Q/formResponse',
-    entries: {
-      name: 'entry.1008715654',
-      email: 'entry.903587259',
-      reason: 'entry.677814908',
-      subject: 'entry.1738397177',
-      message: 'entry.110815800',
-    },
-  },
+  apiEndpoint: (
+    import.meta.env.PUBLIC_CONTACT_API_ENDPOINT || '/api/contact'
+  ).trim(),
 } as const;

--- a/src/lib/contact-form.ts
+++ b/src/lib/contact-form.ts
@@ -514,7 +514,7 @@ export function validateConductReportForm(
   return { valid, errors };
 }
 
-/** Compose a CFS message body for the inbox (and Google Forms fallback). */
+/** Compose a CFS message body for legacy inbox / ack helpers. */
 export function composeCfsMessage(fields: CfsFormFields): string {
   return [
     `Talk title: ${fields.talkTitle.trim()}`,

--- a/tests/unit/functions/contact-dailybot.test.ts
+++ b/tests/unit/functions/contact-dailybot.test.ts
@@ -277,7 +277,7 @@ describe('POST /api/contact → Dailybot', () => {
     const body = JSON.parse(init.body as string) as {
       content: Record<string, string>;
     };
-    expect(body.content[CONDUCT_Q.ANONYMOUS]).toBe('Yes');
+    expect(body.content[CONDUCT_Q.ANONYMOUS]).toBe(true);
     expect(body.content[CONDUCT_Q.REPORTER_NAME]).toBe('');
     expect(body.content[CONDUCT_Q.REPORTER_EMAIL]).toBe('');
     expect(body.content[CONDUCT_Q.INCIDENT]).toContain('confidential incident');

--- a/tests/unit/functions/dailybot.test.ts
+++ b/tests/unit/functions/dailybot.test.ts
@@ -60,11 +60,11 @@ describe('lookupChoice (label values for PTT org)', () => {
 });
 
 describe('booleanToDailyBot', () => {
-  it('maps booleans and common strings to Yes/No', () => {
-    expect(booleanToDailyBot(true)).toBe('Yes');
-    expect(booleanToDailyBot(false)).toBe('No');
-    expect(booleanToDailyBot('sí')).toBe('Yes');
-    expect(booleanToDailyBot('no')).toBe('No');
+  it('maps booleans and common strings to JSON true/false', () => {
+    expect(booleanToDailyBot(true)).toBe(true);
+    expect(booleanToDailyBot(false)).toBe(false);
+    expect(booleanToDailyBot('sí')).toBe(true);
+    expect(booleanToDailyBot('no')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove Google Forms fallback from Contact and newsletter paths so UI success can no longer mask a non-Dailybot submit.
- Default all community intake forms to `POST /api/contact` (`CONTACT_FORM.apiEndpoint`), so CFS/Sponsor/etc. work even when `PUBLIC_CONTACT_API_ENDPOINT` is unset in Cloudflare build env.
- Send Dailybot boolean answers as JSON `true`/`false` (not `"Yes"`/`"No"`), which was rejecting Call for Speakers and Code of Conduct submissions.

## Why
Production on v3 showed Contact as “¡Mensaje enviado!” while nothing appeared in Dailybot (Google Forms no-cors path). Call for Speakers failed with the red delivery error because `apiEndpoint` was baked as `""`.

## Test plan
- [ ] After deploy, view-source `/contact/` — `apiEndpoint` is `/api/contact`, no `docs.google.com/forms` props
- [ ] Submit Contact with `[TEST]` marker → response appears in Dailybot PTT Contact
- [ ] Submit Call for Speakers → Dailybot PTT Call for Speakers (not UI-only error)
- [ ] Spot-check Sponsor / Speaker School / Calendar / CoC (anonymous)
- [ ] `pnpm exec vitest run tests/unit/functions/dailybot.test.ts tests/unit/functions/contact-dailybot.test.ts`


Made with [Cursor](https://cursor.com)