### PR TITLE
ci(release): modernize auto-release as Pereira Tech Talks

### DIFF
--- a/.github/docs/WORKFLOWS.md
+++ b/.github/docs/WORKFLOWS.md
@@ -47,7 +47,7 @@ Complete reference for all GitHub Actions workflows in this repository.
 | Step | Name | What it does |
 |------|------|-------------|
 | — | Checkout | `actions/checkout@v4` with `AUTOMATION_GITHUB_TOKEN`, fetch-depth: 2 |
-| 1 | Setup GitHub Config | Git config + `gh auth login` |
+| 1 | Setup GitHub Config | Git identity `Pereira Tech Talks` + `gh auth login` |
 | 2 | Check PR size label | Reads existing size label from PR |
 | 3 | Calculate PR Size | `git diff --shortstat` → apply size label |
 | 4 | Check title length | Minimum 5 characters |
@@ -130,47 +130,60 @@ For L/XL/XXL PRs, a warning comment is automatically posted.
 | Property | Value |
 |----------|-------|
 | **Trigger** | `pull_request` to `main`, type: `closed` (only when merged) |
-| **Concurrency** | Per-workflow + PR number, cancel in-progress |
+| **Concurrency** | Single group `release-and-publish-main`, **never** cancels in-flight releases |
+| **Permissions** | `contents: write`, `pull-requests: read` |
+| **Git identity** | `Pereira Tech Talks <pereiratechtalks@gmail.com>` |
 
-**Deployment:** Cloudflare Pages deploys automatically on push to `main`. This workflow does **not** deploy. It has **3 chained jobs**:
+**Deployment:** Cloudflare Pages deploys automatically on push to `main`. This workflow does **not** deploy.
 
-### Job 1: `check_pr_size_label`
+### Strategy (and why)
 
-Extracts the PR's size label and maps to emoji for the workflow summary.
+This repo uses a **merge → always patch bump** flow: every merged PR to `main` bumps `package.json` patch, commits/tags as the community bot, pushes to `main`, and opens a GitHub Release.
 
-### Job 2: `release_and_publish` (depends on: Job 1)
+| Approach | Fit for this site | Notes |
+|----------|-------------------|-------|
+| **Current: merge → patch** | Good | Simple for a content-heavy static site; frequent small releases |
+| [release-please](https://github.com/googleapis/release-please) | Strong alternative | Opens a Release PR; tag on merge — works cleanly with “require PR” rulesets without bypass |
+| [semantic-release](https://semantic-release.gitbook.io/) | Overkill here | Needs npm publish + Conventional Commit–driven bumps; heavier for SSG |
 
-| Step | Name | What it does |
-|------|------|-------------|
-| 0-0a | Cache | pnpm store, keyed on `pnpm-lock.yaml` |
-| 2 | Setup GitHub Config | Git config |
-| 3 | Release notes | Runs `scripts/get_github_release_log.sh` |
-| 4 | Prepare release | `corepack pnpm install --frozen-lockfile && corepack pnpm run release` + push tags to main |
-| 5 | Get release tag | Extract latest tag |
-| 6 | Publish release | `ncipollo/release-action@v1` |
+We keep the light flow because most merges are content/docs and a patch bump is enough. If branch-protection bypass for the automation user becomes painful, migrate to **release-please** (PR-based) instead of pushing version commits directly to `main`.
 
-**Helper script:** `scripts/get_github_release_log.sh`
-- Reads `git log --pretty=oneline`
-- Stops at the previous release commit
-- Skips merge commits
-- Prefixes each entry with `🚩`
-- Creates `git_logs_output.txt` as release body
+### Requirements for the automation actor
 
-### Job 3: `cleanup_caches` (depends on: Job 2)
+`AUTOMATION_GITHUB_TOKEN` must:
 
-See [DEPLOYMENT.md](./DEPLOYMENT.md) for Cloudflare Pages setup.
+1. Have permission to push commits + tags to `main`
+2. **Bypass** the ruleset that requires PRs (or be a GitHub App with that bypass)
+3. Be allowed past any required status checks that would block the bot’s version commit
 
-Dispatches a `cleanup_caches` event via GitHub API.
+Without bypass, Prepare release fails with “Changes must be made through a pull request”.
+
+### Job 1: `release_and_publish`
+
+| Step | What it does |
+|------|-------------|
+| Checkout | Full history (`fetch-depth: 0`), `AUTOMATION_GITHUB_TOKEN`, credentials persisted for push |
+| Setup Node / pnpm cache | Node 24.15.0 + pnpm store cache |
+| Configure git identity | Pereira Tech Talks bot |
+| Build release notes | `.github/scripts/get_github_release_log.sh` — commits since last tag |
+| Prepare release | `pnpm run release` (bump/commit/tag) → `git push --follow-tags origin HEAD:main` |
+| Publish GitHub Release | `ncipollo/release-action@v1` with `allowUpdates: true` |
+
+**Helper scripts:**
+
+- `prepare_release.sh` — patch bump via Node, commit `[🤖 Pereira Tech Talks] New release to vX.Y.Z launched 🚀`, annotated tag
+- `get_github_release_log.sh` — changelog from last tag (skips merge + prior release commits)
+
+### Job 2: `cleanup_caches` (depends on: Job 1)
+
+Dispatches a `cleanup_caches` repository event via GitHub API. See [DEPLOYMENT.md](./DEPLOYMENT.md) for Cloudflare Pages setup.
 
 ---
 
 ## Workflow Dependencies
 
 ```
-check_pr_size_label
-         │
-         ▼
-  release_and_publish
+release_and_publish
          │
          ▼
   cleanup_caches

--- a/.github/scripts/get_github_release_log.sh
+++ b/.github/scripts/get_github_release_log.sh
@@ -1,14 +1,39 @@
-git log --pretty=oneline | sed 's/[^ ]* *//' > git_logs.txt
+#!/bin/bash
+# Build release notes from commits since the previous release tag.
+# Falls back to scanning commit subjects until the previous automation
+# release commit when no prior tag exists.
+set -euo pipefail
 
-if [[ -f "git_logs_output.txt" ]]; then
-  rm git_logs_output.txt
+OUT="git_logs_output.txt"
+rm -f "${OUT}"
+
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+if [[ -n "${LAST_TAG}" ]]; then
+  RANGE="${LAST_TAG}..HEAD"
+  mapfile -t LINES < <(git log "${RANGE}" --pretty=format:'%s' --no-merges)
+else
+  mapfile -t LINES < <(git log --pretty=format:'%s' --no-merges)
 fi
 
-while read text_line; do
-  if [[ "$text_line" =~ "[🤖 Sergio Alexander Florez Galeano] New release to v" ]]; then
-    break
+count=0
+for text_line in "${LINES[@]}"; do
+  # Stop / skip automation release commits (current + legacy author names).
+  if [[ "${text_line}" =~ New\ release\ to\ v ]]; then
+    if [[ -z "${LAST_TAG}" ]]; then
+      break
+    fi
+    continue
   fi
-  if [[ ! "$text_line" =~ "Merge branch 'main'" ]] && [[ ! "$text_line" =~ "Merge pull request" ]]; then
-    echo "🚩 $text_line" >> git_logs_output.txt
+  if [[ "${text_line}" =~ ^Merge\ (branch|pull\ request) ]]; then
+    continue
   fi
-done < git_logs.txt
+  echo "- ${text_line}" >> "${OUT}"
+  count=$((count + 1))
+done
+
+if [[ "${count}" -eq 0 ]]; then
+  echo "- Maintenance release" > "${OUT}"
+fi
+
+echo "Wrote ${count} changelog entries to ${OUT}"

--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -9,6 +9,8 @@
 # bump only touches package.json and is safe regardless of untracked state.
 set -euo pipefail
 
+BOT_NAME="${RELEASE_BOT_NAME:-Pereira Tech Talks}"
+
 if ! git diff --quiet HEAD -- .; then
   echo "Tracked files have uncommitted changes. Refusing to prepare a release."
   git status --short --untracked-files=no
@@ -24,7 +26,7 @@ fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 console.log(pkg.version);
 ")
 TAG="v${VERSION}"
-RELEASE_MESSAGE="[🤖 Sergio Alexander Florez Galeano] New release to ${TAG} launched 🚀"
+RELEASE_MESSAGE="[🤖 ${BOT_NAME}] New release to ${TAG} launched 🚀"
 
 git add package.json
 if [[ -f "pnpm-lock.yaml" ]]; then
@@ -38,3 +40,6 @@ fi
 
 git commit -m "${RELEASE_MESSAGE}"
 git tag -a "${TAG}" -m "${TAG}"
+
+echo "Prepared release ${TAG}"
+echo "${TAG}" > .release_tag

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Step 1 - ⚙️ Setup GitHub Config
         run: |
-          git config user.name "Sergio Alexander Florez Galeano"
+          git config user.name "Pereira Tech Talks"
           git config user.email "pereiratechtalks@gmail.com"
           gh auth login --with-token <<< "${{ secrets.AUTOMATION_GITHUB_TOKEN }}"
 

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -1,5 +1,20 @@
 name: Release and Publish
 
+# Auto-release on every merge to main:
+# 1) bump package.json patch
+# 2) commit + tag as the Pereira Tech Talks bot
+# 3) push with AUTOMATION_GITHUB_TOKEN (must bypass rulesets on main)
+# 4) create a GitHub Release
+#
+# Why not release-please / semantic-release yet?
+# This site ships content frequently and uses a simple always-patch bump.
+# PR-based tools (release-please) are excellent when you want reviewable
+# release PRs and Conventional Commit–driven bumps; we keep the lighter
+# merge→patch flow here and document the trade-off in WORKFLOWS.md.
+#
+# Branch protection: AUTOMATION_GITHUB_TOKEN (or a GitHub App) must be
+# allowed to bypass "require pull request" on main for the version commit.
+
 on:
   pull_request:
     branches:
@@ -8,139 +23,95 @@ on:
       - closed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Never cancel an in-flight release (mid-push / mid-tag is unsafe).
+  group: release-and-publish-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
-  check_pr_size_label:
-    if: github.event.pull_request.merged == true
-    name: 'Check PR Size Label'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Step 1 - Check pr size label
-        id: check_pr_size_label_step
-        env:
-          ENV_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
-          SIZE_LABELS: >-
-            "Size - XS","Size - S","Size - M","Size - L","Size - XL","Size - XXL"
-        run: |
-          IFS=',' read -ra SIZE_LABELS_ARR <<< "$SIZE_LABELS"
-          # Remove the quotes from SIZE_LABELS_ARR
-          SIZE_LABELS_ARR=("${SIZE_LABELS_ARR[@]//\"}")
-
-          # Get PR Labels
-          FOUND_LABELS_JSON=$(echo "$ENV_LABELS" | jq -r '.[] | .name')
-
-          readarray -t FOUND_LABELS <<<"$FOUND_LABELS_JSON"
-
-          echo "FOUND LABELS:"
-          printf '%s\n' "${FOUND_LABELS[@]}"
-
-          # Check if any of the labels in FOUND_LABELS is in SIZE_LABELS_ARR
-          SIZE_LABEL_FOUND=''
-          for found_label in "${FOUND_LABELS[@]}"; do
-            for size_label in "${SIZE_LABELS_ARR[@]}"; do
-              if [[ "$found_label" == "$size_label" ]]; then
-                SIZE_LABEL_FOUND=$found_label
-                echo "Label 'SIZE_LABEL_FOUND' found in SIZE_LABELS"
-              fi
-            done
-          done
-
-          SIZE_LABEL_FOUND_EMOJI="❓"
-          if [ "$SIZE_LABEL_FOUND" == "Size - XS" ]; then
-            SIZE_LABEL_FOUND_EMOJI="🟢"
-          elif [ "$SIZE_LABEL_FOUND" == "Size - S" ]; then
-            SIZE_LABEL_FOUND_EMOJI="🟢"
-          elif [ "$SIZE_LABEL_FOUND" == "Size - M" ]; then
-            SIZE_LABEL_FOUND_EMOJI="🟡"
-          elif [ "$SIZE_LABEL_FOUND" == "Size - L" ]; then
-            SIZE_LABEL_FOUND_EMOJI="🟠"
-          elif [ "$SIZE_LABEL_FOUND" == "Size - XL" ]; then
-            SIZE_LABEL_FOUND_EMOJI="🔴"
-          elif [ "$SIZE_LABEL_FOUND" == "Size - XXL" ]; then
-            SIZE_LABEL_FOUND_EMOJI="🔴"
-          fi
-          SIZE_LABEL_FOUND_RESULT="$SIZE_LABEL_FOUND_EMOJI $SIZE_LABEL_FOUND"
-          echo "size_label_found=$SIZE_LABEL_FOUND_RESULT" >> $GITHUB_OUTPUT
-
-    outputs:
-      size_label_found: ${{ steps.check_pr_size_label_step.outputs.size_label_found }}
-
   release_and_publish:
-    needs: check_pr_size_label
+    if: github.event.pull_request.merged == true
     name: 'Release and Publish'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          fetch-depth: '30'
+          fetch-depth: 0
           token: ${{ secrets.AUTOMATION_GITHUB_TOKEN }}
-      - uses: actions/setup-node@v4
+          # Keep the automation token for subsequent git push.
+          persist-credentials: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: '24.15.0'
-          registry-url: https://registry.npmjs.org/
-      - name: Step 0 - 📁 Get pnpm store path
+
+      - name: Get pnpm store path
         id: pnpm-store
         run: |
           STORE_PATH=$(corepack pnpm store path --silent)
           echo "STORE_PATH=${STORE_PATH}" >> "$GITHUB_OUTPUT"
-      - name: Step 0a - 📁 Cache pnpm store
+
+      - name: Cache pnpm store
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-      - name: Step 1 - ⚙️ Setup GitHub Config
+
+      - name: Configure git identity
+        env:
+          RELEASE_BOT_NAME: Pereira Tech Talks
+          RELEASE_BOT_EMAIL: pereiratechtalks@gmail.com
         run: |
-          git config user.name "Sergio Alexander Florez Galeano"
-          git config user.email "pereiratechtalks@gmail.com"
+          git config user.name "${RELEASE_BOT_NAME}"
+          git config user.email "${RELEASE_BOT_EMAIL}"
           git config advice.skippedCherryPicks false
-      - name: Step 2 - 📄 Set GitHub release content "BODY" env var
-        run: |
-          bash .github/scripts/get_github_release_log.sh
-          if [[ ! -f git_logs_output.txt ]]; then
-            echo "⚠️ No description found for release body content."
-            exit 1
-          fi
-      - name: Step 3 - 🔄 Prepare release
+
+      - name: Build release notes
+        run: bash .github/scripts/get_github_release_log.sh
+
+      - name: Prepare release (bump, commit, tag)
+        id: prepare
+        env:
+          RELEASE_BOT_NAME: Pereira Tech Talks
         run: |
           corepack pnpm install --frozen-lockfile
           corepack pnpm run release
-          git push --follow-tags origin main
-      - name: Step 4 - 🏷️ Set GitHub release "TAG" env vars
-        run: |
-          GITHUB_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-          if [[ -z $GITHUB_RELEASE_TAG ]]; then
-            echo "⚠️ No release tag found."
-            exit 1
-          fi
-          echo "::set-env name=GITHUB_RELEASE_TAG::$GITHUB_RELEASE_TAG"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      - name: Step 5 - 🚀 Publish GitHub release
+          TAG="$(cat .release_tag)"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          # Push the release commit + annotated tag to main.
+          # Requires ruleset bypass for the automation actor.
+          git push --follow-tags origin "HEAD:main"
+
+      - name: Publish GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          name: Release ${{ env.GITHUB_RELEASE_TAG }}
-          tag: ${{ env.GITHUB_RELEASE_TAG }}
+          name: Release ${{ steps.prepare.outputs.tag }}
+          tag: ${{ steps.prepare.outputs.tag }}
           bodyFile: git_logs_output.txt
           token: ${{ secrets.AUTOMATION_GITHUB_TOKEN }}
-
-    outputs:
-      package_version: ${{ steps.publish_npm_package.outputs.package_version }}
+          # Idempotent if the workflow is re-run after a partial success.
+          allowUpdates: true
+          makeLatest: true
 
   cleanup_caches:
     needs: release_and_publish
+    if: success()
     name: 'Cleanup caches'
     runs-on: ubuntu-latest
     steps:
-      - name: Step 1 - 🗑️ Trigger cleanup caches workflow
+      - name: Trigger cleanup caches workflow
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN }}
         run: |
-          curl --location "https://api.github.com/repos/$GITHUB_REPOSITORY/dispatches" \
-            --header "Authorization: token ${{ secrets.AUTOMATION_GITHUB_TOKEN }}" \
-            --header "Content-Type: application/json" \
-            --data '{
-                "event_type": "cleanup_caches",
-                "client_payload": {}
-            }'
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f event_type='cleanup_caches' \
+            -f 'client_payload={}'

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ spanish.png
 
 # Playwright ephemeral test output
 test-results/
+
+# CI release scratch files (written by GitHub Actions release scripts)
+.release_tag
+git_logs_output.txt
+packages_upgrades_output.txt

--- a/docs/DEVELOPMENT_COMMANDS.md
+++ b/docs/DEVELOPMENT_COMMANDS.md
@@ -166,7 +166,7 @@ pnpm run release
 
 - Bumps patch version
 - Creates commit with release message
-- Format: `[🤖 Sergio Alexander Florez Galeano] New release to v{version} launched 🚀`
+- Format: `[🤖 Pereira Tech Talks] New release to v{version} launched 🚀`
 
 ## Astro CLI
 

--- a/src/components/cards/MeetupCard.astro
+++ b/src/components/cards/MeetupCard.astro
@@ -82,9 +82,14 @@ const talksLabel =
       loading={loading}
       sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 380px"
       class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" />
-    <div class="absolute left-3 top-3 flex gap-2">
-      <Badge variant={statusVariant}>{statusLabel}</Badge>
-    </div>
+    {
+      /* Archive meetups are all past — skip the redundant "Past"/"Pasado" badge. */
+      status !== 'completed' && (
+        <div class="absolute left-3 top-3 flex gap-2">
+          <Badge variant={statusVariant}>{statusLabel}</Badge>
+        </div>
+      )
+    }
   </div>
   <div class="flex min-w-0 flex-1 flex-col gap-3 p-5">
     <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs font-semibold uppercase tracking-wider text-ptt-primary dark:text-ptt-primary-dark">


### PR DESCRIPTION
## Summary
- Brand release commits/releases as **Pereira Tech Talks** (no personal automation name)
- Modernize `release_and_publish.yml`: explicit permissions, `GITHUB_OUTPUT`, safer concurrency (no cancel mid-release), full history checkout, idempotent GitHub Release publish
- Improve changelog generation from the previous tag; document merge→patch vs release-please trade-offs and ruleset-bypass requirements
- Hide redundant Past/Pasado badge on completed meetup cards

## Test plan
- [ ] Confirm CI Code Check passes on this PR
- [ ] After merge, verify Release and Publish creates a commit like `[🤖 Pereira Tech Talks] New release to vX.Y.Z…`
- [ ] Confirm automation user can push the version bump to `main` (ruleset bypass)
- [ ] Spot-check meetup archive cards: no Past/Pasado badge when status is completed


Made with [Cursor](https://cursor.com)