### PR TITLE
fix(content): meetup EN summaries, join crop, contributor pronouns

### DIFF
--- a/.agents/skills/add-meetup/SKILL.md
+++ b/.agents/skills/add-meetup/SKILL.md
@@ -122,7 +122,7 @@ draft: false
 ---
 ```
 
-Body content is freeform Markdown (program description, schedule, callouts). Keep it bilingual by interleaving short EN and ES sections, or by writing a primary-language body with a `Summary in English` / `Resumen en español` companion section — see the existing meetup files for established patterns.
+Body content is freeform Markdown (program description, schedule, callouts). Write the body in the community primary language (Spanish). Do **not** append a `Summary in English`, `Resumen en español`, or `> **EN:**` companion block — bilingual coverage for listings/SEO comes from frontmatter `title` / `description` (`en` + `es`).
 
 ## Steps
 
@@ -147,7 +147,7 @@ ls src/content/meetups/ | grep "$DATE" || true
 
 Create `src/content/meetups/YYYY-MM-DD_{slug}.md` using the frontmatter template. Translate the title and description into Spanish (informal-professional tuteo). Always include both `en` and `es` keys for `title`, `description`, and `hero.alt`.
 
-**Body** — write a short program description in the primary language (typically Spanish for local meetups), followed by a `### Summary in English` / `### Resumen en español` block summarising the key points in the other language.
+**Body** — write a short program description in Spanish (primary). Rely on bilingual `title` / `description` for the English locale; do not embed an English summary section in the shared body.
 
 ### Step 3: Image Setup (Optional but Recommended)
 
@@ -225,7 +225,7 @@ content: add meetup "{title.en}"
 ## Definition of Done
 
 - [ ] File created at `src/content/meetups/YYYY-MM-DD_{slug}.md`
-- [ ] Both EN and ES content populated (frontmatter + body)
+- [ ] Both EN and ES frontmatter populated (`title`, `description`, `hero.alt`); body in Spanish without an embedded English summary
 - [ ] All references resolve to existing collection entries
 - [ ] `pnpm run biome:check` passes
 - [ ] `pnpm run astro:check` passes
@@ -244,4 +244,5 @@ content: add meetup "{title.en}"
 
 | Version | Date       | Changes |
 | ------- | ---------- | ------- |
+| 1.1.0   | 2026-08-08 | Drop `Summary in English` / `> **EN:**` body companions; bilingual coverage is frontmatter-only for the shared body. |
 | 1.0.0   | 2026-06-01 | Initial skill: bilingual meetup creation with vertical/talk/speaker/sponsor references and AEO twin auto-generation via build. |

--- a/src/components/cards/ContributorCard.astro
+++ b/src/components/cards/ContributorCard.astro
@@ -20,7 +20,6 @@ const role = tr(contributor.data.role, lang);
 const bio = tr(contributor.data.bio, lang);
 const avatar = contributor.data.avatar;
 const social = contributor.data.social ?? {};
-const pronouns = contributor.data.pronouns;
 
 const roleLabels: Record<string, { en: string; es: string }> = {
   'founding-organizer': {
@@ -73,11 +72,6 @@ const portraitAlt =
   <h3 class="mt-4 text-base font-semibold text-ptt">
     {contributor.data.name}
   </h3>
-  {
-    pronouns && (
-      <p class="mt-0.5 text-xs text-ptt-secondary">{pronouns}</p>
-    )
-  }
   <p class="mt-1 text-sm font-medium text-ptt-primary dark:text-ptt-primary-dark">
     {role}
   </p>

--- a/src/components/pereira-tech-days/PtdJoinSection.astro
+++ b/src/components/pereira-tech-days/PtdJoinSection.astro
@@ -141,12 +141,11 @@ const subAfter =
     background-image: var(--ptd-join-bg);
     background-repeat: no-repeat;
     /*
-     * Height-fill + slight overscale: branch flush on the bottom border;
-     * baked cream feather clipped by overflow. Width grows with height so
-     * the monkey reads large across the band.
+     * Height-fill + slight overscale, anchored to the top so the ape’s
+     * head/upper body stay in frame; any overflow clips at the bottom.
      */
     background-size: auto 114%;
-    background-position: left bottom;
+    background-position: left top;
   }
 
   @media (min-width: 1440px) {
@@ -176,9 +175,9 @@ const subAfter =
     }
 
     .ptd-join__bg {
-      /* Stronger overscale on narrow screens so foliage meets the border. */
+      /* Stronger overscale on narrow screens; still crop bottom, not head. */
       background-size: auto 122%;
-      background-position: left bottom;
+      background-position: left top;
     }
   }
 </style>

--- a/src/content/meetups/2014-02-27_primera-reunion-pereirajs-2014.md
+++ b/src/content/meetups/2014-02-27_primera-reunion-pereirajs-2014.md
@@ -36,12 +36,6 @@ Por otro lado [Jhonber Jimenez](https://twitter.com/jh0nb3r) y [Manuel Pineda](h
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2014-02-27: First meeting of PereiraJs. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-03-25_historia-y-oop-en-javascript-2014.md
+++ b/src/content/meetups/2014-03-25_historia-y-oop-en-javascript-2014.md
@@ -42,24 +42,6 @@ Segundo Meetup de PereiraJs en el cual se conto con dos charla muy interesantes 
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **JavaScript Historia y aplicaciones by [Manuel Pineda](https://twitter.com/pin3da) y [Jhonber Jimenez](https://twitter.com/jh0nb3r)** 
- Slides disponibles en: [http://jhonber.github.io/slides](http://jhonber.github.io/slides)
- 
-2. **Programación Orientada a Objetos con JavaScript by [Oscar Granada](https://twitter.com/oagranada)** 
- Slides disponibles en:. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****JavaScript Historia y aplicaciones by [Manuel Pineda](https://twitter.com/pin3da) y [Jhonber Jimenez](https://twitter.com/jh0nb3r)** 
- Slides disponibles en: [http://jhonber.github.io/slides](http://jhonber.github.io/slides)
- 
-2. **Programación Orientada a Objetos con JavaScript by [Oscar Granada](https://twitter.com/oagranada)** 
- Slides disponibles en:**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-04-25_js-cliente-y-servidor-2014.md
+++ b/src/content/meetups/2014-04-25_js-cliente-y-servidor-2014.md
@@ -41,21 +41,6 @@ Tercer Meetup de PereiraJs en el cual se conto con dos charla muy interesantes s
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **Introducción a Javascript del lado del cliente by [Jhonber Jimenez](https://twitter.com/jh0nb3r)**
- Slides disponibles en: · **Introducción a Javascript del lado del servidor by [Daniel Aristizabal](https://twitter.com/cronopio2)**
- Una introducción a Javascript del lado del servidor usando node, explicando programación asíncrona y programación orientada a objetos:. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Introducción a Javascript del lado del cliente by [Jhonber Jimenez](https://twitter.com/jh0nb3r)**
- Slides disponibles en:**
-2. ****Introducción a Javascript del lado del servidor by [Daniel Aristizabal](https://twitter.com/cronopio2)**
- Una introducción a Javascript del lado del servidor usando node, explicando programación asíncrona y programación orientada a objetos:**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-05-21_js-y-nodejs-i-2014.md
+++ b/src/content/meetups/2014-05-21_js-y-nodejs-i-2014.md
@@ -40,19 +40,6 @@ Un pequeño paso para un joven, un gran paso para la tecnología...: http://ogra
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **Aprendiendo Javascript I by [Oscar Granada](https://twitter.com/oagranada)**
-Un pequeño paso para un joven, un gran paso para la tecnología...: http://ogranada.github.io/aprendiendo_javascript_1/#/ · **Inmersión en Node.js I. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Aprendiendo Javascript I by [Oscar Granada](https://twitter.com/oagranada)**
-Un pequeño paso para un joven, un gran paso para la tecnología...: http://ogranada.github.io/aprendiendo_javascript_1/#/**
-1. ****Inmersión en Node.js I** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-06-28_js-y-nodejs-ii-2014.md
+++ b/src/content/meetups/2014-06-28_js-y-nodejs-ii-2014.md
@@ -40,19 +40,6 @@ Una plantilla para el futuro...: http://ogranada.github.io/aprendiendo_javascrip
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **Aprendiendo Javascript II by [Oscar Granada](https://twitter.com/oagranada)**
-Una plantilla para el futuro...: http://ogranada.github.io/aprendiendo_javascript_2 · **Inmersión en Node.js II. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Aprendiendo Javascript II by [Oscar Granada](https://twitter.com/oagranada)**
-Una plantilla para el futuro...: http://ogranada.github.io/aprendiendo_javascript_2**
-1. ****Inmersión en Node.js II** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-07-26_mvc-y-express-flatiron-2014.md
+++ b/src/content/meetups/2014-07-26_mvc-y-express-flatiron-2014.md
@@ -39,18 +39,6 @@ Sexto Meetup de PereiraJs en el cual se conto con dos charla muy interesantes so
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **MV, el camino a las web apps del futuro by [Oscar Granada](https://twitter.com/oagranada)**
-2. **Express.js y Flatiron.js juntos pero no revueltos by [Daniel Aristizabal](https://twitter.com/cronopio2)**. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****MV, el camino a las web apps del futuro by [Oscar Granada](https://twitter.com/oagranada)**
-2. **Express.js y Flatiron.js juntos pero no revueltos by [Daniel Aristizabal](https://twitter.com/cronopio2)****
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-08-25_dom-y-git-2014.md
+++ b/src/content/meetups/2014-08-25_dom-y-git-2014.md
@@ -41,21 +41,6 @@ Slides disponibles en: http://pin3da.github.io/slides/git_github.html** ([perfil
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **Librerías para manipulación del DOM by [Diana M. Bedoya](https://twitter.com/dimabera)**
-Slides disponibles en: http://pereira.js.org/slides/charla_jquery_nov_26_2014.pdf · **Introducción a git y github by [Manuel Pineda](https://twitter.com/pin3da_)**
-Slides disponibles en: http://pin3da.github.io/slides/git_github.html. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Librerías para manipulación del DOM by [Diana M. Bedoya](https://twitter.com/dimabera)**
-Slides disponibles en: http://pereira.js.org/slides/charla_jquery_nov_26_2014.pdf**
-1. ****Introducción a git y github by [Manuel Pineda](https://twitter.com/pin3da_)**
-Slides disponibles en: http://pin3da.github.io/slides/git_github.html**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-09-25_buenas-practicas-js-y-tdd-2014.md
+++ b/src/content/meetups/2014-09-25_buenas-practicas-js-y-tdd-2014.md
@@ -40,19 +40,6 @@ Slides disponibles en: https://speakerdeck.com/jonalvarezz/javascript-best-pract
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **Buenas Prácticas en Javascript by [Jonathan Alvarez](https://twitter.com/jonalvarezz)**
-Slides disponibles en: https://speakerdeck.com/jonalvarezz/javascript-best-practices · **TDD && BDD, Javascript y el buen sabor de las pruebas. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Buenas Prácticas en Javascript by [Jonathan Alvarez](https://twitter.com/jonalvarezz)**
-Slides disponibles en: https://speakerdeck.com/jonalvarezz/javascript-best-practices**
-1. ****TDD && BDD, Javascript y el buen sabor de las pruebas** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2014-12-25_edicion-especial-utp-2014.md
+++ b/src/content/meetups/2014-12-25_edicion-especial-utp-2014.md
@@ -40,19 +40,6 @@ Slides disponibles en: https://speakerdeck.com/jonalvarezz/javascript-best-pract
 
 ---
 
-### Summary in English
-
-A 2014 Pereira Tech Talks meetup featuring **Buenas Prácticas en Javascript by [Jonathan Alvarez](https://twitter.com/jonalvarezz)**
-Slides disponibles en: https://speakerdeck.com/jonalvarezz/javascript-best-practices · **TDD && BDD, Javascript y el buen sabor de las pruebas. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Buenas Prácticas en Javascript by [Jonathan Alvarez](https://twitter.com/jonalvarezz)**
-Slides disponibles en: https://speakerdeck.com/jonalvarezz/javascript-best-practices**
-1. ****TDD && BDD, Javascript y el buen sabor de las pruebas** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2015-01-25_introduccion-a-npm-2015.md
+++ b/src/content/meetups/2015-01-25_introduccion-a-npm-2015.md
@@ -39,18 +39,6 @@ Slides disponibles en: http://cronopio.github.io/slides-intro-npm/** ([perfil](h
 
 ---
 
-### Summary in English
-
-A 2015 Pereira Tech Talks meetup featuring **Introducción a npm by [Daniel Aristizabal](https://twitter.com/cronopio2)**
-Slides disponibles en: http://cronopio.github.io/slides-intro-npm/. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Introducción a npm by [Daniel Aristizabal](https://twitter.com/cronopio2)**
-Slides disponibles en: http://cronopio.github.io/slides-intro-npm/**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2015-03-25_aprendiendo-node-streams-2015.md
+++ b/src/content/meetups/2015-03-25_aprendiendo-node-streams-2015.md
@@ -41,21 +41,6 @@ Slides disponibles en: http://pin3da.github.io/slides** ([perfil](https://twitte
 
 ---
 
-### Summary in English
-
-A 2015 Pereira Tech Talks meetup featuring **Aprendiendo node by [Daniel Aristizabal](https://twitter.com/cronopio2)**
-Slides disponibles en: https://github.com/workshopper/learnyounode · **Streams - Event Emitter by [Manuel Felipe Pineda](https://twitter.com/pin3da_)**
-Slides disponibles en: http://pin3da.github.io/slides. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Aprendiendo node by [Daniel Aristizabal](https://twitter.com/cronopio2)**
-Slides disponibles en: https://github.com/workshopper/learnyounode**
-1. ****Streams - Event Emitter by [Manuel Felipe Pineda](https://twitter.com/pin3da_)**
-Slides disponibles en: http://pin3da.github.io/slides**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2015-09-25_jasmine-y-iojs-2015.md
+++ b/src/content/meetups/2015-09-25_jasmine-y-iojs-2015.md
@@ -40,19 +40,6 @@ Slides disponibles en: http://nbviewer.ipython.org/format/slides/github/DiegoAE/
 
 ---
 
-### Summary in English
-
-A 2015 Pereira Tech Talks meetup featuring **Jasmine, Behavior-Driven Javascript by Diego A. Agudelo España**
-Slides disponibles en: http://nbviewer.ipython.org/format/slides/github/DiegoAE/Talks/blob/master/Jasmine/Jasmine%20Slides.ipynb · **Node.js / IO.js. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Jasmine, Behavior-Driven Javascript by Diego A. Agudelo España**
-Slides disponibles en: http://nbviewer.ipython.org/format/slides/github/DiegoAE/Talks/blob/master/Jasmine/Jasmine%20Slides.ipynb**
-1. ****Node.js / IO.js** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2015-10-25_webassembly-2015.md
+++ b/src/content/meetups/2015-10-25_webassembly-2015.md
@@ -34,12 +34,6 @@ Duodécimo Meetup de PereiraJs conociendo sobre WebAssambly a cargo de [Giovanny
 
 ---
 
-### Summary in English
-
-A 2015 Pereira Tech Talks meetup. Duodécimo Meetup de PereiraJs conociendo sobre WebAssambly a cargo de [Giovanny Gongora](https://twitter.com/Gioyik).
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2015-12-24_zeromq-y-websockets-2015.md
+++ b/src/content/meetups/2015-12-24_zeromq-y-websockets-2015.md
@@ -41,21 +41,6 @@ Slides disponibles en: http://jhonber.github.io/webSockets-slides/** ([perfil](h
 
 ---
 
-### Summary in English
-
-A 2015 Pereira Tech Talks meetup featuring **ZeroMQ + Node.js by [Manuel Pineda](https://twitter.com/pin3da_)**
-Slides disponibles en: http://pin3da.github.io/slides/zeromq_node.html · **WebSockets y Socket.io by [Jhon Jimenez](https://twitter.com/jh0nb3r)**
-Slides disponibles en: http://jhonber.github.io/webSockets-slides/. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****ZeroMQ + Node.js by [Manuel Pineda](https://twitter.com/pin3da_)**
-Slides disponibles en: http://pin3da.github.io/slides/zeromq_node.html**
-1. ****WebSockets y Socket.io by [Jhon Jimenez](https://twitter.com/jh0nb3r)**
-Slides disponibles en: http://jhonber.github.io/webSockets-slides/**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2016-01-25_introduccion-a-mvc-y-node-v4.md
+++ b/src/content/meetups/2016-01-25_introduccion-a-mvc-y-node-v4.md
@@ -39,18 +39,6 @@ Decimocuarto Meetup de PereiraJs hablando sobre:
 
 ---
 
-### Summary in English
-
-A 2016 Pereira Tech Talks meetup featuring **Introducción a MV by [Oscar Granada](https://twitter.com/oagranada)**
-1. **Node.js v4 by [Daniel Aristizabal](https://twitter.com/cronopio2)**. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Introducción a MV by [Oscar Granada](https://twitter.com/oagranada)**
-1. **Node.js v4 by [Daniel Aristizabal](https://twitter.com/cronopio2)****
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2016-01-31_reactive-programming-y-es6.md
+++ b/src/content/meetups/2016-01-31_reactive-programming-y-es6.md
@@ -36,12 +36,6 @@ Slides disponibles en: http://jonalvarezz.github.io/presentation-reactive-progra
 
 ---
 
-### Summary in English
-
-A 2016 Pereira Tech Talks meetup. Decimoquinto Meetup de PereiraJs hablando sobre programación reactiva y EcmaScript 6 a cargo de [Jonathan Alvarez](https://twitter.com/jonalvarezz). Slides disponibles en: http://jonalvarezz.github.io/presentation-reactive-programming/.
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2016-02-25_p2p-y-meteorjs-2016.md
+++ b/src/content/meetups/2016-02-25_p2p-y-meteorjs-2016.md
@@ -40,17 +40,6 @@ Slides disponibles en: http://pin3da.github.io/slides/p2p** ([perfil](https://tw
 
 ---
 
-### Summary in English
-
-A 2016 Pereira Tech Talks meetup featuring **P2P + webtorrent** by [Manuel Pineda](https://twitter.com/pin3da_) (slides: http://pin3da.github.io/slides/p2p) and **Node.js v4** by Sergio A. Florez (slides no longer available). The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **P2P + webtorrent** — [Manuel Pineda](https://twitter.com/pin3da_) (slides: http://pin3da.github.io/slides/p2p)
-2. **Node.js v4** — Sergio A. Florez _(slides no longer available)_
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2016-03-25_js-y-nodejs-introduccion-2016.md
+++ b/src/content/meetups/2016-03-25_js-y-nodejs-introduccion-2016.md
@@ -40,19 +40,6 @@ Slides disponibles en: http://jonalvarezz.github.io/intro-js/** ([perfil](https:
 
 ---
 
-### Summary in English
-
-A 2016 Pereira Tech Talks meetup featuring **Introducción a Javascript by [Jonathan Alvarez](https://twitter.com/jonalvarezz)**
-Slides disponibles en: http://jonalvarezz.github.io/intro-js/ · **Introducción a NodeJs. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Introducción a Javascript by [Jonathan Alvarez](https://twitter.com/jonalvarezz)**
-Slides disponibles en: http://jonalvarezz.github.io/intro-js/**
-2. ****Introducción a NodeJs** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2016-04-25_three-js-y-react-2016.md
+++ b/src/content/meetups/2016-04-25_three-js-y-react-2016.md
@@ -40,19 +40,6 @@ Slides disponibles en: http://jonalvarezz.github.io/react-talk/** ([perfil](http
 
 ---
 
-### Summary in English
-
-A 2016 Pereira Tech Talks meetup featuring **Three JS · **Jonathan Alvarez by [Daniel Aristizabal](https://twitter.com/jonalvarezz)**
-Slides disponibles en: http://jonalvarezz.github.io/react-talk/. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Three JS** — Gabriel Muñoz**
-2. ****Jonathan Alvarez by [Daniel Aristizabal](https://twitter.com/jonalvarezz)**
-Slides disponibles en: http://jonalvarezz.github.io/react-talk/**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-02-28_jwt-json-web-tokens-2017.md
+++ b/src/content/meetups/2017-02-28_jwt-json-web-tokens-2017.md
@@ -36,12 +36,6 @@ En esta oportunidad [Carlos González](https://www.facebook.com/CarloS.GonzaleZ.
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2017-02-28: Learning sobre JWT (JSON web Tokens). Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-03-28_iot-y-clustering-nodejs-2017.md
+++ b/src/content/meetups/2017-03-28_iot-y-clustering-nodejs-2017.md
@@ -41,17 +41,6 @@ Aprenderas que es el internet de las cosas (IoT) y porque es considerado como un
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup featuring **Introducción al Internet de las cosas usando Javascript · **Administración de un pequeño cluster con #nodeJS, aplicado en laboratorio de Sirius de la UTP. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Introducción al Internet de las cosas usando Javascript** — **
-2. ****Administración de un pequeño cluster con #nodeJS, aplicado en laboratorio de Sirius de la UTP** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-05-09_chatbots-y-es6-2017.md
+++ b/src/content/meetups/2017-05-09_chatbots-y-es6-2017.md
@@ -41,17 +41,6 @@ Aprenderas como construir chatbots en Javascript haciendo uso de frameworks y li
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup featuring **Construyendo interfaces conversacionales con Javascript · **Emacscript 6 y Webpack. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Construyendo interfaces conversacionales con Javascript** — **
-2. ****Emacscript 6 y Webpack** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-05-30_sails-websockets-y-grafana-2017.md
+++ b/src/content/meetups/2017-05-30_sails-websockets-y-grafana-2017.md
@@ -41,17 +41,6 @@ Conoceras cómo puedes contruir de manera casí automatizada APIs reactivas medi
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup featuring **APIs y WebSockets con SailsJs · **Monitoreo y visualización de datos con StatsD y Grafana. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****APIs y WebSockets con SailsJs** — **
-2. ****Monitoreo y visualización de datos con StatsD y Grafana** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-07-04_ionic-angular-y-solidity-2017.md
+++ b/src/content/meetups/2017-07-04_ionic-angular-y-solidity-2017.md
@@ -36,12 +36,6 @@ Una noche muy emocionante en PereiraJs con charlas muy interesantes sobre:
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup. Una noche muy emocionante en PereiraJs con charlas muy interesantes sobre: **Desarrollo móvil con Ionic + Angular by [Julian Patiño](https://www.meetup.com/es-ES/PereiraJs_/members/230813066/)**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-08-01_react-native-y-npm-2017.md
+++ b/src/content/meetups/2017-08-01_react-native-y-npm-2017.md
@@ -41,17 +41,6 @@ Hoy en día el tráfico en la red a través de dispositivo móviles supera en gr
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup featuring **Introduccion a React Native · **Exponiendo credenciales de npm sin ningún fallo. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. ****Introduccion a React Native** — **
-2. ****Exponiendo credenciales de npm sin ningún fallo** — **
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-09-14_airflow-y-tensorflow-2017.md
+++ b/src/content/meetups/2017-09-14_airflow-y-tensorflow-2017.md
@@ -36,12 +36,6 @@ En nuestra apertura presentaremos dos charlas muy interesantes:
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup. Tenemos el gusto de invitarlos al primer Meetup de Pereira Tech Talks; comunidad impulsada por talento Pereirano en busqueda de compartir conocimiento tecnológico y conectar con el talento local y regional. En nuestra apertura presentaremos dos charlas muy interesantes:
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/242657174)

--- a/src/content/meetups/2017-09-19_servidor-web-nodejs-2017.md
+++ b/src/content/meetups/2017-09-19_servidor-web-nodejs-2017.md
@@ -36,12 +36,6 @@ Slides disponibles en: http://slides.com/rockalabs/creando-un-servidor-web-con-n
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2017-09-19: Building a web server web desde cero con NodeJs. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-09-20_que-es-el-blockchain-2017.md
+++ b/src/content/meetups/2017-09-20_que-es-el-blockchain-2017.md
@@ -36,12 +36,6 @@ _Slides no longer available._
 
 ---
 
-### Summary in English
-
-A 2017 Pereira Tech Talks meetup. Estuvimos presentes en Universidad de Caldas con una ponencia sobre Blockchain a cargo de Sergio Alexander Florez, contando sus origenes en relación con la historia del dinero y la economía, hasta sus aplicaciones potenciales como la gran…
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2017-10-19_vision-artificial-y-haskell-2017.md
+++ b/src/content/meetups/2017-10-19_vision-artificial-y-haskell-2017.md
@@ -38,12 +38,6 @@ En **Pereira Tech Talks **tenemos el gusto de invitarlos a nuestro segundo Meet
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2017-10-19: Computer Vision con OpenCV && Programación funcional en Haskell. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/243860589)

--- a/src/content/meetups/2017-11-23_seguridad-informatica-y-proteccion-legal-2017.md
+++ b/src/content/meetups/2017-11-23_seguridad-informatica-y-proteccion-legal-2017.md
@@ -38,12 +38,6 @@ En Pereira Tech Talks tenemos el gusto de invitarlos a nuestro tercer Meetup, 
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2017-11-23: Getting Started en seguridad informática && Protección legal de la innovación. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/244859180)

--- a/src/content/meetups/2017-12-11_nginx-y-elasticsearch-2017.md
+++ b/src/content/meetups/2017-12-11_nginx-y-elasticsearch-2017.md
@@ -38,12 +38,6 @@ Tenemos el gusto de invitarlos a nuestro último Meetup del año con dos charlas
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2017-12-11: Introduction a servidores web NGINX && Motores de busqueda con Elasticsearch. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/245689908)

--- a/src/content/meetups/2018-01-14_hackaton-planificacion-2018.md
+++ b/src/content/meetups/2018-01-14_hackaton-planificacion-2018.md
@@ -36,12 +36,6 @@ En enero nos reunimos en conjunto las comunidades de **[Pereira Tech Talks](http
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup. En enero nos reunimos en conjunto las comunidades de **[Pereira Tech Talks](https://pereiratechtalks.org)** y **[Pereira Js](https://pereira.js.org/)** a pasar un buen rato, con el propósito de planificar el nuevo año y como buenos geeks que somos a ¡codear hasta el amanecer!;…
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2018-02-06_noche-de-devops-ansible-y-gitlab-2018.md
+++ b/src/content/meetups/2018-02-06_noche-de-devops-ansible-y-gitlab-2018.md
@@ -41,17 +41,6 @@ Hoy en día el número de servidores que los sysadmin deben administrar crece a 
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring Introducción a la automatización en Ansible · Aprendiendo Integración continua (CI) con GitLab y Docker. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Introducción a la automatización en Ansible** — Manuel Pineda
-2. **Aprendiendo Integración continua (CI) con GitLab y Docker** — Carlos Gónzales
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/247349603)

--- a/src/content/meetups/2018-02-24_realidad-virtual-y-ramda-2018.md
+++ b/src/content/meetups/2018-02-24_realidad-virtual-y-ramda-2018.md
@@ -41,17 +41,6 @@ Hoy en día, la web es la plataforma de distribución masiva más importante, es
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring Realidad Virtual para la web con A-Frame · Point-free Javascript con RamdaJS. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Realidad Virtual para la web con A-Frame**
-2. **Point-free Javascript con RamdaJS**
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2018-04-09_d3-y-mean-stack-2018.md
+++ b/src/content/meetups/2018-04-09_d3-y-mean-stack-2018.md
@@ -36,12 +36,6 @@ El pasado 5 de abril fue una noche éxitosa para PereiraJs, con nuevos speakers 
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2018-04-09: Visualización de datos con d3.js && Desarrollo de aplicaciones usando MEAN Stack. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2018-04-09_redes-neuronales-keras-2018.md
+++ b/src/content/meetups/2018-04-09_redes-neuronales-keras-2018.md
@@ -36,12 +36,6 @@ En colaboración con [científicas de datos](https://www.facebook.com/cientifica
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup. En colaboración con [científicas de datos](https://www.facebook.com/cientificasdedatos/), el pasado 18 de abril tuvimos un gran meetup con [Sebastián Vega](https://twitter.com/sebasvega95) y [Leiver Andres Campeón](https://twitter.com/leiverandres), dos destacados estudiantes de…
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2018-04-18_bitcoin-y-blockchain-2018.md
+++ b/src/content/meetups/2018-04-18_bitcoin-y-blockchain-2018.md
@@ -43,17 +43,6 @@ Contacto: [https://twitter.com/MonoMesa](https://twitter.com/MonoMesa)
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring Qué es el Bitcoin y cómo funciona, origen e historia · Blockchain: La revolución industrial de internet más allá del Bitcoin. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Qué es el Bitcoin y cómo funciona, origen e historia**
-2. **Blockchain: La revolución industrial de internet más allá del Bitcoin**
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/249625568)

--- a/src/content/meetups/2018-05-24_noche-de-testing-2018.md
+++ b/src/content/meetups/2018-05-24_noche-de-testing-2018.md
@@ -41,17 +41,6 @@ En nuestro próximo Meetup, tendremos dos conferencias donde hablaremos de maner
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring Pruebas unitarias en Javascript · Pruebas unitarias en Python. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Pruebas unitarias en Javascript** — John Darwin Morales
-2. **Pruebas unitarias en Python** — Carlos Álvaro
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/250815878)

--- a/src/content/meetups/2018-06-05_maraton-utp-2018.md
+++ b/src/content/meetups/2018-06-05_maraton-utp-2018.md
@@ -34,12 +34,6 @@ El pasado sábado 2 de junio, se realizó en la Universidad Tecnológica de Pere
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup. El pasado sábado 2 de junio, se realizó en la Universidad Tecnológica de Pereira la "**Maratón Interna UTP 2018**" organizada por el semillero de investigación In-silico. Dicha competencia contó con la participación de 11 equipos de las universidades Tecnológica de Pereira (UTP)…
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2018-06-23_nodeschool-day-pereira-2018.md
+++ b/src/content/meetups/2018-06-23_nodeschool-day-pereira-2018.md
@@ -43,19 +43,6 @@ El pasado sabado 23 de Junio tuvo lugar el NodeSchool Day Pereira, impulsado por
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring:
-
-1. **Welcome to NodeSchool Pereira and the PereiraJs community** — Sergio Alexander Florez _(slides no longer available)_
-2. [**JavaScript Fundamentals**](https://gitlab.com/caal-15/custom-javascripting)
-3. [**Learn You Node (Node.js workshop)**](https://github.com/jointDeveloper/learnyounode)
-4. [**Peer-to-peer networks in Node.js**](https://gitlab.com/pin3da/p2p-talk)
-
-The community gathered for talks, networking, and snacks.
-
----
-
 ### Fuentes / Sources
 
 - Photos, slide links, and recordings are still being recovered from community archives — pull requests welcome.

--- a/src/content/meetups/2018-08-21_design-night-2018.md
+++ b/src/content/meetups/2018-08-21_design-night-2018.md
@@ -43,21 +43,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring Diseño para desarrolladores by Laura Aguirre
-🧙‍♀️ Diseñadora de producto ( · Tendencias de Diseño by Daniel Vásquez
-🧙‍♂️ Diseñador Visual / Ilustrador Digital (. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Diseño para desarrolladores by Laura Aguirre
-🧙‍♀️ Diseñadora de producto (**
-2. **Tendencias de Diseño by Daniel Vásquez
-🧙‍♂️ Diseñador Visual / Ilustrador Digital (**
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/253647647)

--- a/src/content/meetups/2018-12-13_noche-de-devops-docker-y-kubernetes-2018.md
+++ b/src/content/meetups/2018-12-13_noche-de-devops-docker-y-kubernetes-2018.md
@@ -41,17 +41,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2018 Pereira Tech Talks meetup featuring Introducción a Docker · Introducción a Kubernetes. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Introducción a Docker** — Sergio Florez
-2. **Introducción a Kubernetes** — Héctor F. Jiménez
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/257037605)

--- a/src/content/meetups/2019-03-13_noche-de-serverless-y-seguridad-2019.md
+++ b/src/content/meetups/2019-03-13_noche-de-serverless-y-seguridad-2019.md
@@ -41,17 +41,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2019 Pereira Tech Talks meetup featuring Aprendiendo Serverless con enfásis en IoT · Seguridad Informática en instituciones del eje cafetero y OWASP. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Aprendiendo Serverless con enfásis en IoT** — Sergio Florez
-2. **Seguridad Informática en instituciones del eje cafetero y OWASP** — Santiago Bernal
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/259446080)

--- a/src/content/meetups/2019-03-16_pereira-girls-day-2019.md
+++ b/src/content/meetups/2019-03-16_pereira-girls-day-2019.md
@@ -36,12 +36,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2019-03-16: Pereira Girls Day. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/259646321)

--- a/src/content/meetups/2019-04-25_automatizacion-de-infraestructura-y-linux.md
+++ b/src/content/meetups/2019-04-25_automatizacion-de-infraestructura-y-linux.md
@@ -41,17 +41,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2019 Pereira Tech Talks meetup featuring IaC: Automatizando nuestra infraestructura · Hablemos de Linux. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **IaC: Automatizando nuestra infraestructura** — Luis Uribe
-2. **Hablemos de Linux** — Harold Sánchez Ospina
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/260589719)

--- a/src/content/meetups/2019-06-05_aprendiendo-bases-de-datos-nosql-y-rails.md
+++ b/src/content/meetups/2019-06-05_aprendiendo-bases-de-datos-nosql-y-rails.md
@@ -41,17 +41,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2019 Pereira Tech Talks meetup featuring Introducción a las bases de datos NoSQL · Desarrolla posibilidades con Rails. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Introducción a las bases de datos NoSQL** — Germán Grandas
-2. **Desarrolla posibilidades con Rails** — Jonatan Gutiérrez
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/261814865)

--- a/src/content/meetups/2019-07-25_de-cero-a-super-heroe-go-kubernetes.md
+++ b/src/content/meetups/2019-07-25_de-cero-a-super-heroe-go-kubernetes.md
@@ -41,17 +41,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2019 Pereira Tech Talks meetup featuring Introducción al desarrollo de aplicaciones modernas en Go · Kubernetes && Serverless en Google Cloud de Cero a Super Heroe. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Introducción al desarrollo de aplicaciones modernas en Go** — Sergio Alexander Florez
-2. **Kubernetes && Serverless en Google Cloud de Cero a Super Heroe** — Mauricio Cuenca
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/263207408)

--- a/src/content/meetups/2019-09-07_saturday-tech-talks-2019.md
+++ b/src/content/meetups/2019-09-07_saturday-tech-talks-2019.md
@@ -43,19 +43,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A 2019 Pereira Tech Talks meetup featuring Next.js: Server-side rendering your React App · Introducción a Amazon Web Services (AWS) · Patrones de arquitectura - Android · Desarrollo serverless de interfaces conversacionales en Amazon Alexa y Google Home. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Next.js: Server-side rendering your React App** — Andrés Rodriguez Escudero
-2. **Introducción a Amazon Web Services (AWS)** — Steven Pineda Cortes
-3. **Patrones de arquitectura - Android** — Zorayda Gutiérrez Montes
-4. **Desarrollo serverless de interfaces conversacionales en Amazon Alexa y Google Home** — Sergio Alexander Florez Galeano
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/264304830)

--- a/src/content/meetups/2019-09-19_meetup-virtual-code-review-y-auth0.md
+++ b/src/content/meetups/2019-09-19_meetup-virtual-code-review-y-auth0.md
@@ -42,17 +42,6 @@ Esten atentos a este link para entrar a la charla virtual a las 6:30pm:
 
 ---
 
-### Summary in English
-
-A 2019 Pereira Tech Talks meetup featuring Code Review, engineering practices · IDaaS at Scale, Cómo evolucionamos los sistemas en @auth0 los últimos 5 años. The community gathered for talks, networking, and snacks.
-
-**Talks:**
-
-1. **Code Review, engineering practices** — Manuel Pineda
-2. **IDaaS at Scale, Cómo evolucionamos los sistemas en @auth0 los últimos 5 años** — Damián Schenkelman
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/264973350)

--- a/src/content/meetups/2020-04-02_quarantine-tech-talks-2020-2.md
+++ b/src/content/meetups/2020-04-02_quarantine-tech-talks-2020-2.md
@@ -39,12 +39,6 @@ En colaboración con las comunidades del eje cafetero les traemos un meetup carg
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2020-04-02: Quarantine Tech Talks 💻 - Meetup 2. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/269780095)

--- a/src/content/meetups/2020-04-11_quarantine-tech-talks-2020-3.md
+++ b/src/content/meetups/2020-04-11_quarantine-tech-talks-2020-3.md
@@ -38,12 +38,6 @@ Las comunidades del eje cafetero se unen para realizar durante esta cuarentena e
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2020-04-11: Quarantine Tech Talks 💻 - Meetup 3. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/269942102)

--- a/src/content/meetups/2020-04-16_quarantine-tech-talks-2020-4.md
+++ b/src/content/meetups/2020-04-16_quarantine-tech-talks-2020-4.md
@@ -39,12 +39,6 @@ Las comunidades del eje cafetero se unen para realizar durante esta cuarentena e
 
 ---
 
-### Summary in English
-
-A 2020 Pereira Tech Talks meetup. Detalles ===== LINK DE REGISTRO ======== [https://quarantinetechtalks4.eventbrite.com](https://quarantinetechtalks4.eventbrite.com) Link Youtube: [https://www.youtube.com/watch?v=9D_PGb03Ov0](https://www.youtube.com/watch?v=9D_PGb03Ov0) Las comunidades del eje cafetero se unen…
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/270081031)

--- a/src/content/meetups/2020-04-23_quarantine-tech-talks-2020-5.md
+++ b/src/content/meetups/2020-04-23_quarantine-tech-talks-2020-5.md
@@ -38,12 +38,6 @@ Las comunidades del eje cafetero se unen para realizar durante esta cuarentena e
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2020-04-23: Quarantine Tech Talks - Meetup 5. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/270217972)

--- a/src/content/meetups/2020-05-21_quarantine-tech-talks-2020-6.md
+++ b/src/content/meetups/2020-05-21_quarantine-tech-talks-2020-6.md
@@ -38,12 +38,6 @@ Las comunidades del eje cafetero se unen para realizar durante esta cuarentena e
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2020-05-21: Quarantine Tech Talks - Meetup 6. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/270745121)

--- a/src/content/meetups/2020-12-25_quarantine-tech-talks-2020-overview.md
+++ b/src/content/meetups/2020-12-25_quarantine-tech-talks-2020-overview.md
@@ -36,12 +36,6 @@ las Quarantine Tech Talks fueron una serie de eventos virtuales que se realizaro
 
 ---
 
-### Summary in English
-
-A 2020 Pereira Tech Talks meetup. las Quarantine Tech Talks fueron una serie de eventos virtuales que se realizaron durante la cuarentena en el año 2020. A continuación se listan los eventos realizados durante este periodo: ### 2 de abril - [Quarantine Tech Talks 💻 - Meetup…
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/269942102)

--- a/src/content/meetups/2021-03-13_tdd-y-microservicios-2021.md
+++ b/src/content/meetups/2021-03-13_tdd-y-microservicios-2021.md
@@ -36,12 +36,6 @@ Para esta oportunidad Facundo García nos hablara sobre Test Driven Development 
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2021-03-13: TDD y Microservicios. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/276757820)

--- a/src/content/meetups/2021-06-17_gcp-y-owasp-2021.md
+++ b/src/content/meetups/2021-06-17_gcp-y-owasp-2021.md
@@ -39,12 +39,6 @@ Bio: Zorayda es una apasionada por la creatividad, innovación y entrega a lo qu
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2021-06-17: GCP y OWASP. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/278665825)

--- a/src/content/meetups/2021-07-28_software-libre-y-automatizacion-2021.md
+++ b/src/content/meetups/2021-07-28_software-libre-y-automatizacion-2021.md
@@ -39,12 +39,6 @@ Bio: Steven, ingeniero de sistemas, economista y candidato a magister en ingenie
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2021-07-28: Open Source y Automatización. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/279620621)

--- a/src/content/meetups/2022-01-12_noche-de-machine-learning-2022.md
+++ b/src/content/meetups/2022-01-12_noche-de-machine-learning-2022.md
@@ -36,12 +36,6 @@ Comenzamos el año cargado de valiosa información. Y con estos dos titanes de G
 
 ---
 
-### Summary in English
-
-A 2022 Pereira Tech Talks meetup. Noche de Machine Learning y Google Interview. Comenzamos el año cargado de valiosa información. Y con estos dos titanes de Google que quieren compartirnos su conocimiento. Sean todos bienvenidos a este primer meetUp del año.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/283129605)

--- a/src/content/meetups/2022-02-03_noche-de-career-path-2022.md
+++ b/src/content/meetups/2022-02-03_noche-de-career-path-2022.md
@@ -36,12 +36,6 @@ En esta charla Óscar nos compartirá su experiencia, nos hablará de su career 
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2022-02-03: Career Path Night con Óscar Barajas de Platzi. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/283655889)

--- a/src/content/meetups/2022-05-12_noche-de-liderazgo-y-testing-2022.md
+++ b/src/content/meetups/2022-05-12_noche-de-liderazgo-y-testing-2022.md
@@ -36,12 +36,6 @@ Por Sergio Estrella, Web UI Developer en Globant, estudiante en la Universidad T
 
 ---
 
-### Summary in English
-
-A 2022 Pereira Tech Talks meetup. Introducción a Load Testing y Observability con K6 y New Relic Por Sergio Estrella, Web UI Developer en Globant, estudiante en la Universidad Tecnológica de Pereira y Platzi Master, mentor en ProTalento.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/285770133)

--- a/src/content/meetups/2022-06-23_noche-de-seguridad-y-testing-2022.md
+++ b/src/content/meetups/2022-06-23_noche-de-seguridad-y-testing-2022.md
@@ -41,12 +41,6 @@ Revisaremos las ventajas, técnicas e importancia del testing para el desarrollo
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2022-06-23: Security Night y  Testing. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/286473532)

--- a/src/content/meetups/2022-09-29_noche-de-accesibilidad-y-ios-2022.md
+++ b/src/content/meetups/2022-09-29_noche-de-accesibilidad-y-ios-2022.md
@@ -38,12 +38,6 @@ Luego me interese por el desarrollo especializado en iOS para productos de apple
 
 ---
 
-### Summary in English
-
-A 2022 Pereira Tech Talks meetup. **Cómo comenzar en el desarrollo de iOS** Yennifer Hurtado Arce. yo comencé como programadora hace como 3 años comencé con web (html Js CSS React) en un bootcamp de programación llamado Laboratoria en Perú que busca impulsar a mujeres en tecnología. Luego me interese por el…
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/288702513)

--- a/src/content/meetups/2022-11-17_noche-de-experiencias-en-software-2022.md
+++ b/src/content/meetups/2022-11-17_noche-de-experiencias-en-software-2022.md
@@ -37,12 +37,6 @@ Esta es una charla más orientada a las personas que tienen curiosidad en la ind
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2022-11-17: Industry Experiences Night en la industria del Software. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/289498758)

--- a/src/content/meetups/2023-05-17_noche-de-ia-y-chatgpt-2023.md
+++ b/src/content/meetups/2023-05-17_noche-de-ia-y-chatgpt-2023.md
@@ -36,12 +36,6 @@ draft: false
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2023-05-17: AI Night & ChatGPT: Tendencias y Posibilidades. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/293065563)

--- a/src/content/meetups/2024-03-07_explorando-cicd-tekton-y-github-actions.md
+++ b/src/content/meetups/2024-03-07_explorando-cicd-tekton-y-github-actions.md
@@ -48,12 +48,6 @@ En esta charla se hará una introducción a los conceptos básicos de Tekton, un
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-03-07: Exploring CI/CD: Tekton en Kubernetes y GitHub Actions . Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/299312744)

--- a/src/content/meetups/2024-04-25_tecnologias-de-vanguardia-svelte-y-blockchain.md
+++ b/src/content/meetups/2024-04-25_tecnologias-de-vanguardia-svelte-y-blockchain.md
@@ -46,12 +46,6 @@ Tal vez pienses que el blockchain es solo para actividades ilegales o una apuest
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-04-25: Technologies de Vanguardia: Svelte y Blockchain al descubierto.. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/300358357)

--- a/src/content/meetups/2024-05-30_revolucionando-el-deep-learning.md
+++ b/src/content/meetups/2024-05-30_revolucionando-el-deep-learning.md
@@ -57,12 +57,6 @@ Resumen: El Deep Learning ha supuesto una revolución en el campo del Machine Le
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-05-30: Revolutionizing el Deep Learning: Potenciando modelos con datos limitados. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/301101493)

--- a/src/content/meetups/2024-06-27_noche-de-unity-2024.md
+++ b/src/content/meetups/2024-06-27_noche-de-unity-2024.md
@@ -58,12 +58,6 @@ En esta charla hablaremos sobre Build Profiles, una nueva forma de configurar la
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-06-27: Unity Night: Primeros pasos, Shaders & Build Profiles. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/301707617)

--- a/src/content/meetups/2024-08-01_desarrollo-web-moderno-con-astro.md
+++ b/src/content/meetups/2024-08-01_desarrollo-web-moderno-con-astro.md
@@ -58,12 +58,6 @@ Descubre cómo Astro está transformando el desarrollo web con ejemplos práctic
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-08-01: Web Development Moderno: Construyendo sitios web más rápido y ligeros con Astro. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/302332376)

--- a/src/content/meetups/2024-08-29_tech-soft-skills-ia-y-trabajo-remoto.md
+++ b/src/content/meetups/2024-08-29_tech-soft-skills-ia-y-trabajo-remoto.md
@@ -57,12 +57,6 @@ En un mundo globalizado, las oportunidades laborales no tienen fronteras. Descub
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-08-29: Tech & Soft Skills: IA, Trabajo Remoto y Apredizaje Ágil. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/302972719)

--- a/src/content/meetups/2024-09-26_machine-learning-y-automatizaciones.md
+++ b/src/content/meetups/2024-09-26_machine-learning-y-automatizaciones.md
@@ -56,12 +56,6 @@ Aprenderemos cómo la nube, especialmente con herramientas de AWS como SageMaker
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-09-26: Machine Learning, Automatizaciones, Videojuegos y Más.. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/303545199)

--- a/src/content/meetups/2024-10-30_ia-en-accion-2024.md
+++ b/src/content/meetups/2024-10-30_ia-en-accion-2024.md
@@ -53,12 +53,6 @@ Ubicación y cómo encontrarnos: Nos reuniremos en la Universidad Católica de P
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-10-30: AI in Action: Aprende a entrenar y personalizar tu propio modelo desde casa. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/304127870)

--- a/src/content/meetups/2024-11-28_tecnologia-con-proposito.md
+++ b/src/content/meetups/2024-11-28_tecnologia-con-proposito.md
@@ -59,12 +59,6 @@ Charla sobre cómo crear tecnología consciente con las personas, accesible, fun
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-11-28: Technology con Propósito: Conexiones Humanas y Colaboración Inteligente. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/304596503)

--- a/src/content/meetups/2024-12-12_de-la-utp-a-la-academia-y-lo-empresarial.md
+++ b/src/content/meetups/2024-12-12_de-la-utp-a-la-academia-y-lo-empresarial.md
@@ -66,12 +66,6 @@ Parte de la conversación incluye compartir algunos de los tips que me mantuvier
 
 ---
 
-### Summary in English
-
-A Pereira Tech Talks meetup on 2024-12-12: From UTP a la Academia y lo Empresarial: Historias de Crecimiento Profesional. Full program notes are in the Spanish section above; community archives and original Meetup/Luma links are listed under Sources.
-
----
-
 ### Fuentes / Sources
 
 - Original event page: [Meetup.com](https://www.meetup.com/pereira-tech-talks/events/304596568)

--- a/src/content/meetups/2025-02-22_inauguracion-gdg-pereira.md
+++ b/src/content/meetups/2025-02-22_inauguracion-gdg-pereira.md
@@ -32,7 +32,4 @@ draft: false
 ## Inauguración GDG Pereira
 
 Las comunidades tech de Pereira — Pereira Tech Talks, CINCO, Pereira JS, JointDeveloper y Python Pereira — se unieron para inaugurar el capítulo local de Google Developer Groups.
-
-> **EN:** Pereira tech communities — Pereira Tech Talks, CINCO, Pereira JS, JointDeveloper, and Python Pereira — joined forces to launch the local Google Developer Groups chapter.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-03-26_conoce-a-la-cloud-native-computing-foundation.md
+++ b/src/content/meetups/2025-03-26_conoce-a-la-cloud-native-computing-foundation.md
@@ -36,7 +36,4 @@ draft: false
 ## Conoce a la Cloud Native Computing Foundation
 
 Introducción a la CNCF, sus proyectos insignia (Kubernetes, Prometheus) y el momento adecuado para migrar tus cargas de trabajo a Kubernetes.
-
-> **EN:** An introduction to the CNCF, its flagship projects (Kubernetes, Prometheus), and the right moment to migrate your workloads to Kubernetes.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-04-24_noche-de-ai-generativa-2025.md
+++ b/src/content/meetups/2025-04-24_noche-de-ai-generativa-2025.md
@@ -37,7 +37,4 @@ draft: false
 ## Noche de AI Generativa: generación procedural y descubrimiento de fármacos
 
 Dos charlas sobre IA generativa — generación procedural en videojuegos (mundos al estilo Minecraft) y LLMs aplicados a la investigación en biotecnología.
-
-> **EN:** Two talks on generative AI — procedural generation in games (Minecraft-style worlds) and applied LLMs in biotech research.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-05-21_continuous-testing-paralelizacion-y-observabilidad.md
+++ b/src/content/meetups/2025-05-21_continuous-testing-paralelizacion-y-observabilidad.md
@@ -36,7 +36,4 @@ draft: false
 ## Continuous Testing: Paralelización de Pruebas y Observabilidad
 
 Meetup sobre continuous testing — escalar la automatización de pruebas sin escalar el equipo y convertir la suite en una herramienta de observabilidad en tiempo real.
-
-> **EN:** A meetup on continuous testing — scaling automated test suites without scaling headcount, and turning your tests into a real-time observability tool.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-06-18_aprendiendo-con-vibe-coding.md
+++ b/src/content/meetups/2025-06-18_aprendiendo-con-vibe-coding.md
@@ -37,7 +37,4 @@ draft: false
 ## Aprendiendo con Vibe Coding
 
 Meetup sobre vibe coding — pair-programming con agentes de IA para entregar software real más rápido sin salir del flow.
-
-> **EN:** A meetup on vibe coding — pair-programming with AI agents to ship real software faster while staying in flow.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-07-23_noche-de-rust-2025.md
+++ b/src/content/meetups/2025-07-23_noche-de-rust-2025.md
@@ -36,7 +36,4 @@ draft: false
 ## Noche de Rust 2025
 
 Meetup sobre Rust — fundamentos, por qué las empresas están apostando por él y un vistazo en vivo a cómo se siente Rust en producción.
-
-> **EN:** A meetup on Rust — fundamentals, why companies are betting on it, and a live look at what production Rust feels like.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-08-13_noche-de-python-2025.md
+++ b/src/content/meetups/2025-08-13_noche-de-python-2025.md
@@ -36,7 +36,4 @@ draft: false
 ## Noche de Python 2025
 
 Inmersión en Python — desde ingeniería de datos hasta frameworks web y herramientas de IA. La comunidad Python de Pereira dice presente.
-
-> **EN:** Python deep-dives — from data engineering to web frameworks to AI tooling. The Python community in Pereira shows up.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-09-24_conociendo-la-nube.md
+++ b/src/content/meetups/2025-09-24_conociendo-la-nube.md
@@ -32,7 +32,4 @@ draft: false
 ## Conociendo la nube
 
 Una jornada de charlas sobre Rust y cloud-native — desarrollo moderno, seguro y de alto rendimiento para la próxima década.
-
-> **EN:** A day of Rust and cloud-native talks — modern, safe, high-performance development for the next decade.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-10-29_conversatorio-hackathon.md
+++ b/src/content/meetups/2025-10-29_conversatorio-hackathon.md
@@ -32,7 +32,4 @@ draft: false
 ## Conversatorio PerTT: ¿Qué es una Hackathon?
 
 Conversatorio sobre la cultura de hackathons, qué esperar y cómo organizar la primera en Pereira.
-
-> **EN:** A panel-style conversation about hackathon culture, what to expect, and how to organize your first one in Pereira.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-11-19_lightning-talks-2025-11.md
+++ b/src/content/meetups/2025-11-19_lightning-talks-2025-11.md
@@ -33,7 +33,4 @@ draft: false
 ## Pereira Tech Lightning Talks — Noviembre 2025
 
 Un meetup de charlas exprés sobre soft skills, GenAI, self-hosting, UI, UX y más — primeras oportunidades de escenario para ponentes nuevos.
-
-> **EN:** A meetup of express talks on soft skills, GenAI, self-hosting, UI, UX, and more — first-stage opportunities for new speakers.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2025-12-10_el-futuro-de-la-ia.md
+++ b/src/content/meetups/2025-12-10_el-futuro-de-la-ia.md
@@ -36,7 +36,4 @@ draft: false
 ## El Futuro de la IA: Código, Hardware y Agentes
 
 Meetup de cierre de año sobre cómo la IA está transformando la ingeniería de software — agentes, LLMs, RAG y la IA conversando con hardware real.
-
-> **EN:** Year-end meetup on how AI is transforming software engineering — agents, LLMs, RAG, and AI talking to real-world hardware.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2026-02-17_de-vuetify-a-edge-computing.md
+++ b/src/content/meetups/2026-02-17_de-vuetify-a-edge-computing.md
@@ -36,7 +36,4 @@ draft: false
 ## Desde Vuetify hasta el Edge Computing — Meetup de Apertura 2026
 
 Meetup de apertura de 2026 — reflexiones sobre el ecosistema Vuetify más una inmersión en edge computing. Charlas, snacks y networking.
-
-> **EN:** Opening meetup of 2026 — Vuetify ecosystem reflections plus an edge-computing deep dive. Talks, snacks, and networking.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2026-03-08_mujeres-en-tecnologia-2026.md
+++ b/src/content/meetups/2026-03-08_mujeres-en-tecnologia-2026.md
@@ -36,7 +36,4 @@ draft: false
 ## Mujeres en Tecnología
 
 Meetup del mes de la mujer en tecnología — celebramos el impacto de las mujeres en tech con conversaciones sobre creatividad, IA y comunidad.
-
-> **EN:** Women in Tech month meetup — celebrating the impact of women in technology with conversations on creativity, AI, and community.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2026-04-17_abril-mobile-2026.md
+++ b/src/content/meetups/2026-04-17_abril-mobile-2026.md
@@ -36,7 +36,4 @@ draft: false
 ## Abril Mobile
 
 Mes del desarrollo mobile: Kotlin Multiplatform, native vs. cross-platform y el futuro del mobile en 2026.
-
-> **EN:** Mobile development month: Kotlin Multiplatform, native vs. cross-platform trade-offs, and the future of mobile in 2026.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2026-05-27_ia-como-motor-de-crecimiento.md
+++ b/src/content/meetups/2026-05-27_ia-como-motor-de-crecimiento.md
@@ -37,7 +37,4 @@ draft: false
 ## IA como motor de crecimiento
 
 Meetup sobre AI Engineering, IA como infraestructura y cómo escalar sistemas de IA en entornos empresariales. Charlas con Sebastián Franco Gomez y Henry Bravo.
-
-> **EN:** A meetup on AI Engineering, AI as infrastructure, and how to scale AI systems in enterprise environments. Talks by Sebastián Franco Gomez and Henry Bravo.
-
 Originally published on Meetup.com / Luma — see the link in the frontmatter for full details.

--- a/src/content/meetups/2026-06-24_qa-pilar-del-software.md
+++ b/src/content/meetups/2026-06-24_qa-pilar-del-software.md
@@ -67,9 +67,3 @@ Por **Laura Daniela Santa**, Software Testing Analyst en Evertec.
 - **Entrada libre.** Habrá snacks y sorteos.
 
 Agradecemos a DailyBot, Aumentada, ASE-UTP y Vuetify por hacer posible este encuentro.
-
-### Summary in English
-
-June's meetup puts software quality at the centre. Two complementary talks: **Juan Alejandro Pérez Bermúdez** (DailyBot) traces more than 40 years of open-source history to show how code review, testing, documentation, and governance became the quality practices holding up much of the internet — from Linux and PostgreSQL to Kubernetes and AI. Then **Laura Daniela Santa** (Evertec) makes the case that QA is worth far more than end-of-process bug hunting: involved early, it anticipates risk and shapes business decisions.
-
-Wednesday 24 June 2026, 6:30 PM (Colombia time), at UTP Block 13, Sala Magistral 1, Pereira. Free entry, with snacks and giveaways. Thanks to DailyBot, Aumentada, ASE-UTP, and Vuetify for supporting the meetup.


### PR DESCRIPTION
## Summary
- Remove embedded `Summary in English` / `> **EN:**` blocks from meetup bodies (bilingual coverage stays in frontmatter `title` / `description`); update `add-meetup` skill accordingly
- Anchor the PTD `#join` brochure illustration to the top so the ape’s head stays in frame and overflow clips at the bottom
- Hide `she/her` / `he/him` pronouns on Equipo contributor cards

## Test plan
- [ ] `/meetups/qa-pilar-del-software/` and a historical meetup (e.g. reactive-programming): no “Summary in English”; Fuentes sections still present where they existed
- [ ] `/en/meetups/...`: English title/description; shared Spanish body without EN companion block
- [ ] `/pereira-tech-day#join` (desktop ~1000px): top of the ape visible; bottom may crop
- [ ] `/contributors` and `/en/contributors`: cards show name → role → bio, no pronouns line


Made with [Cursor](https://cursor.com)