### PR TITLE
fix(sponsors): compact past partners for clearer hierarchy

### DIFF
--- a/docs/features/SPONSORS.md
+++ b/docs/features/SPONSORS.md
@@ -6,8 +6,8 @@ Community partners directory at `/sponsors` (EN: `/en/sponsors`).
 
 1. **Hero** — partnership framing + dual CTAs (`/sponsor-us`, `/contact`)
 2. **Why sponsor** — three concrete value props
-3. **Current partners** — flat grid of `status: active` (no PTD tier headings)
-4. **Past partners** — flat grid of `status: past`
+3. **Current partners** — rich cards for `status: active` (logo + name + description; no PTD tier headings)
+4. **Past partners** — compact logo tiles for `status: past` (smaller logos, denser grid, no description) so current partners keep hierarchy
 
 **Per-edition tiers** (diamond/gold/silver/bronze/community) belong on **Pereira Tech Day** edition pages via `sponsoredEditions` / `getEditionSponsors` — not on this catalog.
 
@@ -25,7 +25,7 @@ YAML in `src/content/sponsors/{slug}.yaml`:
 ## Components
 
 - `SponsorsPage.astro` — community catalog
-- `SponsorCard.astro` — `showTier={false}` on community page
+- `SponsorCard.astro` — `showTier={false}` on community page; `muted` for past compact tiles
 - `src/lib/sponsor.ts` — `getActiveSponsors` / `getPastSponsors` sort by order; `sortSponsors` still tier-aware for PTD
 
 ## Adding a partner

--- a/src/components/cards/SponsorCard.astro
+++ b/src/components/cards/SponsorCard.astro
@@ -1,6 +1,9 @@
 ---
 /**
  * Sponsor card for community catalog and (optionally) tiered PTD contexts.
+ *
+ * `muted` = past-partner compact tile (smaller logo/name, no description) so
+ * current sponsors keep visual hierarchy on `/sponsors`.
  */
 
 import type { CollectionEntry } from 'astro:content';
@@ -18,7 +21,7 @@ interface Props {
   tier?: CollectionEntry<'sponsors'>['data']['tier'];
   /** Community catalog hides PTD-style tier badges. */
   showTier?: boolean;
-  /** Quieter treatment for past partners. */
+  /** Quieter, compact treatment for past partners. */
   muted?: boolean;
 }
 
@@ -45,6 +48,9 @@ const logoLight = sponsor.data.logo.light;
 const logoDark = sponsor.data.logo.dark;
 const logoAlt = sponsor.data.logo.alt;
 const sameLogo = logoLight === logoDark;
+
+const logoWidth = muted ? 120 : 160;
+const logoHeight = muted ? 40 : 64;
 ---
 
 <a
@@ -52,24 +58,41 @@ const sameLogo = logoLight === logoDark;
   target="_blank"
   rel="noopener noreferrer"
   class:list={[
-    'group flex h-full min-w-0 flex-col rounded-2xl p-4 sm:p-6 transition motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary',
+    'group flex min-w-0 transition motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary',
     muted
-      ? 'bg-ptt-bg-elevated/80 shadow-none ring-1 ring-ptt-border/70 hover:ring-ptt-border dark:bg-ptt-bg-dark/40'
-      : 'bg-ptt-bg-elevated shadow-sm ring-1 ring-ptt-border hover:shadow-lg hover:ring-ptt-primary/30',
+      ? 'h-full flex-col items-center justify-center gap-2 rounded-xl bg-ptt-bg-elevated/60 px-3 py-4 text-center shadow-none ring-1 ring-ptt-border/50 hover:ring-ptt-border dark:bg-ptt-bg-dark/30 sm:px-4 sm:py-5'
+      : 'h-full flex-col rounded-2xl bg-ptt-bg-elevated p-4 shadow-sm ring-1 ring-ptt-border hover:shadow-lg hover:ring-ptt-primary/30 sm:p-6',
   ]}
 >
-  <div class="flex flex-wrap items-start justify-between gap-3 sm:gap-4">
-    <div class="flex h-16 w-36 max-w-full min-w-0 items-center">
+  <div
+    class:list={[
+      muted
+        ? 'flex h-10 w-full max-w-[7.5rem] items-center justify-center'
+        : 'flex flex-wrap items-start justify-between gap-3 sm:gap-4',
+    ]}
+  >
+    <div
+      class:list={[
+        muted
+          ? 'flex h-10 w-full items-center justify-center'
+          : 'flex h-16 w-36 max-w-full min-w-0 items-center',
+      ]}
+    >
       {
         sameLogo ? (
           <img
             decoding="async"
             src={logoLight}
             alt={logoAlt}
-            width="160"
-            height="64"
+            width={logoWidth}
+            height={logoHeight}
             loading={loading}
-            class="max-h-16 max-w-full object-contain"
+            class:list={[
+              'max-w-full object-contain',
+              muted
+                ? 'max-h-10 opacity-80 grayscale-[35%] transition group-hover:opacity-100 group-hover:grayscale-0'
+                : 'max-h-16',
+            ]}
           />
         ) : (
           <>
@@ -77,30 +100,52 @@ const sameLogo = logoLight === logoDark;
               decoding="async"
               src={logoLight}
               alt={logoAlt}
-              width="160"
-              height="64"
+              width={logoWidth}
+              height={logoHeight}
               loading={loading}
-              class="max-h-16 max-w-full object-contain dark:hidden"
+              class:list={[
+                'max-w-full object-contain dark:hidden',
+                muted
+                  ? 'max-h-10 opacity-80 grayscale-[35%] transition group-hover:opacity-100 group-hover:grayscale-0'
+                  : 'max-h-16',
+              ]}
             />
             <img
               decoding="async"
               src={logoDark}
               alt={logoAlt}
-              width="160"
-              height="64"
+              width={logoWidth}
+              height={logoHeight}
               loading={loading}
-              class="hidden max-h-16 max-w-full object-contain dark:block"
+              class:list={[
+                'hidden max-w-full object-contain dark:block',
+                muted
+                  ? 'max-h-10 opacity-80 grayscale-[35%] transition group-hover:opacity-100 group-hover:grayscale-0'
+                  : 'max-h-16',
+              ]}
             />
           </>
         )
       }
     </div>
-    {showTier && <Badge variant={tier}>{tierLabel[tier][lang]}</Badge>}
+    {
+      !muted && showTier && (
+        <Badge variant={tier}>{tierLabel[tier][lang]}</Badge>
+      )
+    }
   </div>
-  <h3 class="mt-4 text-lg font-semibold text-ptt group-hover:text-ptt-primary">
+  <h3
+    class:list={[
+      muted
+        ? 'text-xs font-medium leading-snug text-ptt-secondary group-hover:text-ptt'
+        : 'mt-4 text-lg font-semibold text-ptt group-hover:text-ptt-primary',
+    ]}
+  >
     {sponsor.data.name}
   </h3>
-  <p class="mt-2 text-sm text-ptt-secondary line-clamp-3">
-    {description}
-  </p>
+  {
+    !muted && (
+      <p class="mt-2 text-sm text-ptt-secondary line-clamp-3">{description}</p>
+    )
+  }
 </a>

--- a/src/components/pages/SponsorsPage.astro
+++ b/src/components/pages/SponsorsPage.astro
@@ -108,11 +108,20 @@ const whyItems = [sp.why.items.meetups, sp.why.items.ptd, sp.why.items.talent];
 
   {
     pastSponsors.length > 0 && (
-      <Section surface="alt" spacing="lg" title={sp.pastTitle}>
-        <p class="mb-10 max-w-3xl text-ptt-secondary">{sp.pastIntro}</p>
-        <ul class="grid list-none gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <Section surface="alt" spacing="sm">
+        {/*
+          Quieter archive chrome vs current sponsors: smaller heading, denser
+          logo tiles (SponsorCard muted), less vertical mass.
+        */}
+        <header class="mb-8 max-w-2xl sm:mb-10">
+          <h2 class="text-xl font-semibold tracking-tight text-ptt sm:text-2xl">
+            {sp.pastTitle}
+          </h2>
+          <p class="mt-2 text-sm text-ptt-secondary sm:text-base">{sp.pastIntro}</p>
+        </header>
+        <ul class="grid list-none grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {pastSponsors.map((sponsor) => (
-            <li class="opacity-90 transition-opacity motion-reduce:transition-none hover:opacity-100">
+            <li>
               <SponsorCard sponsor={sponsor} lang={lang} showTier={false} muted />
             </li>
           ))}


### PR DESCRIPTION
## Summary
- Past sponsors on `/sponsors` render as compact logo tiles (smaller mark, name only, denser grid, soft grayscale)
- Current sponsors keep full cards (logo + name + description)
- Quieter “Patrocinadores anteriores” section chrome; docs note the hierarchy pattern

## Test plan
- [ ] `/sponsors` and `/en/sponsors`: current section still shows rich cards with descriptions
- [ ] Past section: smaller tiles, no bios, denser grid (up to 6 cols on xl)
- [ ] Past logos slightly muted/grayscale; full color on hover
- [ ] Dark mode: past + current logos still readable


Made with [Cursor](https://cursor.com)