### PR TITLE
feat(sponsors): add sponsor profile pages with derived meetup history

### DIFF
--- a/docs/features/SPONSORS.md
+++ b/docs/features/SPONSORS.md
@@ -1,15 +1,48 @@
 # Sponsors — Feature Guide
 
-Community partners directory at `/sponsors` (EN: `/en/sponsors`).
+Community partners directory at `/sponsors` (EN: `/en/sponsors`) plus one
+**partner profile** per sponsor at `/sponsors/{slug}` (EN: `/en/sponsors/{slug}`).
 
-## Page IA
+## Page IA — directory (`/sponsors`)
 
 1. **Hero** — partnership framing + dual CTAs (`/sponsor-us`, `/contact`)
 2. **Why sponsor** — three concrete value props
-3. **Current partners** — rich cards for `status: active` (logo + name + description; no PTD tier headings)
-4. **Past partners** — compact logo tiles for `status: past` (smaller logos, denser grid, no description) so current partners keep hierarchy
+3. **Current sponsors** — cards for `status: active` (logo + name + description + `View sponsored meetups →` / `Website ↗`)
+4. **Past sponsors** — compact logo tiles for `status: past` (smaller logos, denser grid, profile link only) so current sponsors keep hierarchy
 
-**Per-edition tiers** (diamond/gold/silver/bronze/community) belong on **Pereira Tech Day** edition pages via `sponsoredEditions` / `getEditionSponsors` — not on this catalog.
+The directory carries **no counters** — no aggregate strip, no per-card numbers.
+It stays a scannable wall of logos whose job is to get you to a profile; the
+sponsorship numbers live there, where they have context. Both sections use the
+same single label (`View sponsored meetups` / `Ver meetups patrocinados`) — it
+names the reason to click, which a neutral "view profile" does not.
+
+## Vocabulary
+
+Say **sponsor / patrocinador**, never *partner / aliado*, anywhere in this
+domain — UI labels, sponsor YAML descriptions, `/sponsor-us` tiers, and the
+agent Markdown endpoints. *Aliado* stays reserved for **allied communities**
+(`/communities` — PereiraJS, Python Pereira, …), which are a different
+relationship and are not sponsors.
+
+**Per-edition tiers** (diamond/gold/silver/bronze/community) belong on **Pereira Tech Day** edition pages via `getEditionSponsors` — not on this catalog.
+
+## Page IA — partner profile (`/sponsors/{slug}`)
+
+1. **Header** — logo panel, status badge (current/past), "backing the community since {year}", description, `Visit website ↗` + `All sponsors`
+2. **Stat tiles** — sponsored meetups · PTD editions · talks enabled · speakers on stage (each tile rendered only when > 0)
+3. **Upcoming sponsored meetups** — `MeetupCard` grid, rendered only when the partner backs a future meetup
+4. **Sponsored meetups** — archive grouped by year (descending), newest year first
+5. **Pereira Tech Day editions** — `EditionCard` per sponsored year with the per-edition tier badge
+6. **Empty state** — logo-only partners with nothing linked yet
+7. **Sponsorship CTA** — `/sponsor-us` + `/contact`
+
+`Organization` JSON-LD is emitted per profile, with up to 20 sponsored meetups as `subjectOf` events.
+
+## Link topology
+
+- Sponsor card → partner profile (primary, internal); sponsor website is a separate, explicitly marked external link
+- Meetup detail → sponsor tiles link to the partner profile (reciprocal loop `meetup ↔ sponsor`)
+- PTD `PtdSponsorsShowcase` keeps its **outbound** logo links — those are a paid edition deliverable and are deliberately untouched
 
 ## Content
 
@@ -19,14 +52,38 @@ YAML in `src/content/sponsors/{slug}.yaml`:
 |-------|--------|
 | `status` | `active` \| `past` — drives community page sections |
 | `tier` | Kept for PTD; **not** shown as section headings on `/sponsors` |
-| `sponsoredEditions` | `{ year, tier }[]` for edition showcases |
+| `sponsoredEditions` | `{ year, tier }[]` — **fallback only**, for PTD years without an entry in the `pereiraTechDays` collection |
 | `order` | Sort within current/past |
+
+**Sponsorship history is derived, never hand-written.** The source of truth is the
+event side of the graph — `meetups[].sponsors[]` and `pereiraTechDays[].sponsors[]`.
+To make a sponsor show up on a meetup, add the `{ slug, tier }` ref to that
+meetup's frontmatter; the profile page, counters, and agent Markdown all follow
+automatically.
 
 ## Components
 
-- `SponsorsPage.astro` — community catalog
-- `SponsorCard.astro` — `showTier={false}` on community page; `muted` for past compact tiles
-- `src/lib/sponsor.ts` — `getActiveSponsors` / `getPastSponsors` sort by order; `sortSponsors` still tier-aware for PTD
+- `SponsorsPage.astro` — community catalog + impact strip
+- `SponsorDetailPage.astro` — partner profile (`/sponsors/{slug}`)
+- `SponsorCard.astro` — `showTier={false}` on community page; `muted` for past compact tiles; optional `activity` prop drives the counters
+- `src/lib/sponsor.ts`:
+  - `getActiveSponsors` / `getPastSponsors` sort by order; `sortSponsors` still tier-aware for PTD
+  - `getSponsorBySlug`, `getMeetupsBySponsor`
+  - `buildSponsorActivity(slug, meetups, editions, sponsoredEditions, today)` — pure, unit-tested resolver
+  - `getSponsorActivity(sponsor)` — single profile; `getSponsorActivityMap(sponsors)` — one pass for the whole grid
+  - `SPONSOR_TIER_LABELS` — shared singular tier names (plural section headings stay in i18n)
+
+## Routes
+
+| Route | File |
+|-------|------|
+| `/sponsors/{slug}` | `src/pages/sponsors/[slug].astro` |
+| `/en/sponsors/{slug}` | `src/pages/en/sponsors/[slug].astro` |
+| `/sponsors/{slug}.md` | `src/pages/sponsors/[slug].md.ts` |
+| `/en/sponsors/{slug}.md` | `src/pages/en/sponsors/[slug].md.ts` |
+
+`sponsors` is already in the middleware allowlist; nested paths bypass the
+single-segment rule, so no `src/middleware.ts` change is needed.
 
 ## Adding a partner
 

--- a/src/components/cards/SponsorCard.astro
+++ b/src/components/cards/SponsorCard.astro
@@ -1,14 +1,21 @@
 ---
 /**
- * Sponsor card for community catalog and (optionally) tiered PTD contexts.
+ * Sponsor card for the community catalog and (optionally) tiered PTD contexts.
  *
- * `muted` = past-partner compact tile (smaller logo/name, no description) so
+ * UX contract: the card's primary action is the *internal* sponsor profile
+ * (`/sponsors/{slug}`), where the sponsored-meetup history lives. The sponsor's
+ * own website stays available as an explicit, clearly-marked external link so
+ * the outbound click is a deliberate choice, not a surprise.
+ *
+ * `muted` = past-sponsor compact tile (smaller logo/name, no description) so
  * current sponsors keep visual hierarchy on `/sponsors`.
  */
 
 import type { CollectionEntry } from 'astro:content';
 import Badge from '@/components/ui/Badge.astro';
-import { type Language, tr } from '@/lib/i18n';
+import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
+import { SPONSOR_TIER_LABELS, type SponsorActivity } from '@/lib/sponsor';
+import { getTranslations } from '@/lib/translations';
 
 interface Props {
   sponsor: CollectionEntry<'sponsors'>;
@@ -21,8 +28,10 @@ interface Props {
   tier?: CollectionEntry<'sponsors'>['data']['tier'];
   /** Community catalog hides PTD-style tier badges. */
   showTier?: boolean;
-  /** Quieter, compact treatment for past partners. */
+  /** Quieter, compact treatment for past sponsors. */
   muted?: boolean;
+  /** Derived sponsorship history; its presence enables the profile link. */
+  activity?: SponsorActivity;
 }
 
 const {
@@ -32,22 +41,28 @@ const {
   tier: tierProp,
   showTier = true,
   muted = false,
+  activity,
 } = Astro.props;
 
+const t = getTranslations(lang);
+const card = t.sponsorsPage.card;
+const prefix = getUrlPrefix(lang);
+const profileUrl = `${prefix}/sponsors/${sponsor.id}/`;
+
 const tier = tierProp ?? sponsor.data.tier;
-const tierLabel: Record<typeof tier, { en: string; es: string }> = {
-  diamond: { en: 'Diamond', es: 'Diamante' },
-  gold: { en: 'Gold', es: 'Oro' },
-  silver: { en: 'Silver', es: 'Plata' },
-  bronze: { en: 'Bronze', es: 'Bronce' },
-  community: { en: 'Community', es: 'Comunidad' },
-};
 
 const description = tr(sponsor.data.description, lang);
 const logoLight = sponsor.data.logo.light;
 const logoDark = sponsor.data.logo.dark;
 const logoAlt = sponsor.data.logo.alt;
 const sameLogo = logoLight === logoDark;
+
+/**
+ * The card stays a logo + pitch; the sponsorship numbers live on the profile.
+ * One label for every sponsor, current or past — "sponsored meetups" reads as
+ * the reason to click, which a neutral "view profile" does not.
+ */
+const profileLabel = card.viewSponsoredMeetups;
 
 const logoWidth = muted ? 120 : 160;
 const logoHeight = muted ? 40 : 64;
@@ -67,38 +82,35 @@ const logoDisplayWidth = muted ? logoWidth : isWideWordmark ? 192 : logoWidth;
 const logoDisplayHeight = muted ? logoHeight : isWideWordmark ? 46 : logoHeight;
 ---
 
-<a
-  href={sponsor.data.url}
-  target="_blank"
-  rel="noopener noreferrer"
+<article
   class:list={[
-    'group flex min-w-0 transition motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary',
+    'group flex min-w-0 h-full flex-col transition motion-reduce:transition-none',
     muted
-      ? 'h-full flex-col items-center justify-center gap-2 rounded-xl bg-ptt-bg-elevated/60 px-3 py-4 text-center shadow-none ring-1 ring-ptt-border/50 hover:ring-ptt-border dark:bg-ptt-bg-dark/30 sm:px-4 sm:py-5'
-      : 'h-full flex-col items-center rounded-2xl bg-ptt-bg-elevated p-4 text-center shadow-sm ring-1 ring-ptt-border hover:shadow-lg hover:ring-ptt-primary/30 sm:p-6',
+      ? 'items-center justify-center gap-2 rounded-xl bg-ptt-bg-elevated/60 px-3 py-4 text-center shadow-none ring-1 ring-ptt-border/50 hover:ring-ptt-border dark:bg-ptt-bg-dark/30 sm:px-4 sm:py-5'
+      : 'items-center rounded-2xl bg-ptt-bg-elevated p-4 text-center shadow-sm ring-1 ring-ptt-border hover:shadow-lg hover:ring-ptt-primary/30 sm:p-6',
   ]}
+  data-umami-event="sponsor_card_view"
+  data-umami-event-slug={sponsor.id}
 >
-  <div
+  <a
+    href={profileUrl}
+    data-umami-event="sponsor_card_click"
+    data-umami-event-slug={sponsor.id}
     class:list={[
-      muted
-        ? 'flex h-10 w-full max-w-[7.5rem] items-center justify-center'
-        : 'flex w-full flex-col items-center gap-3',
+      'flex min-w-0 max-w-full flex-col items-center focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary',
+      muted ? 'gap-2' : 'w-full gap-3',
     ]}
   >
-    <div class={logoBoxClass}>
-      {
-        sameLogo ? (
-          <img
-            decoding="async"
-            src={logoLight}
-            alt={logoAlt}
-            width={logoDisplayWidth}
-            height={logoDisplayHeight}
-            loading={loading}
-            class:list={['max-w-full object-contain', logoImgClass]}
-          />
-        ) : (
-          <>
+    <div
+      class:list={[
+        muted
+          ? 'flex h-10 w-full max-w-[7.5rem] items-center justify-center'
+          : 'flex w-full flex-col items-center gap-3',
+      ]}
+    >
+      <div class={logoBoxClass}>
+        {
+          sameLogo ? (
             <img
               decoding="async"
               src={logoLight}
@@ -106,42 +118,105 @@ const logoDisplayHeight = muted ? logoHeight : isWideWordmark ? 46 : logoHeight;
               width={logoDisplayWidth}
               height={logoDisplayHeight}
               loading={loading}
-              class:list={['max-w-full object-contain dark:hidden', logoImgClass]}
+              class:list={['max-w-full object-contain', logoImgClass]}
             />
-            <img
-              decoding="async"
-              src={logoDark}
-              alt={logoAlt}
-              width={logoDisplayWidth}
-              height={logoDisplayHeight}
-              loading={loading}
-              class:list={[
-                'hidden max-w-full object-contain dark:block',
-                logoImgClass,
-              ]}
-            />
-          </>
+          ) : (
+            <>
+              <img
+                decoding="async"
+                src={logoLight}
+                alt={logoAlt}
+                width={logoDisplayWidth}
+                height={logoDisplayHeight}
+                loading={loading}
+                class:list={[
+                  'max-w-full object-contain dark:hidden',
+                  logoImgClass,
+                ]}
+              />
+              <img
+                decoding="async"
+                src={logoDark}
+                alt={logoAlt}
+                width={logoDisplayWidth}
+                height={logoDisplayHeight}
+                loading={loading}
+                class:list={[
+                  'hidden max-w-full object-contain dark:block',
+                  logoImgClass,
+                ]}
+              />
+            </>
+          )
+        }
+      </div>
+      {
+        !muted && showTier && (
+          <Badge variant={tier}>{SPONSOR_TIER_LABELS[tier][lang]}</Badge>
         )
       }
     </div>
-    {
-      !muted && showTier && (
-        <Badge variant={tier}>{tierLabel[tier][lang]}</Badge>
-      )
-    }
-  </div>
-  <h3
-    class:list={[
-      muted
-        ? 'text-xs font-medium leading-snug text-ptt-secondary transition-colors group-hover:text-ptt-primary dark:group-hover:text-ptt-primary-dark'
-        : 'mt-4 text-lg font-semibold text-ptt group-hover:text-ptt-primary',
-    ]}
-  >
-    {sponsor.data.name}
-  </h3>
+    <h3
+      class:list={[
+        muted
+          ? 'text-xs font-medium leading-snug text-ptt-secondary transition-colors group-hover:text-ptt-primary dark:group-hover:text-ptt-primary-dark'
+          : 'mt-1 text-lg font-semibold text-ptt group-hover:text-ptt-primary',
+      ]}
+    >
+      {sponsor.data.name}
+    </h3>
+  </a>
+
   {
-    !muted && (
-      <p class="mt-2 text-sm text-ptt-secondary line-clamp-3">{description}</p>
+    /*
+      Past sponsors get the same "see what they funded" affordance as current
+      ones — just the link, no counter: the archive grid is dense and the count
+      is already on the profile. Only on surfaces that pass `activity` (the
+      /sponsors archive); inside a meetup detail the tile stays a plain logo link.
+    */
+    muted && activity && (
+      <a
+        href={profileUrl}
+        aria-label={`${profileLabel} — ${sponsor.data.name}`}
+        data-umami-event="sponsor_meetups_click"
+        data-umami-event-slug={sponsor.id}
+        class="mt-auto inline-flex min-h-[44px] items-center justify-center gap-1 text-center text-[0.6875rem] font-semibold leading-snug text-ptt-primary hover:underline dark:text-ptt-primary-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary"
+      >
+        {profileLabel}
+        <span aria-hidden="true">→</span>
+      </a>
     )
   }
-</a>
+
+  {
+    !muted && (
+      <>
+        <p class="mt-3 text-sm text-ptt-secondary line-clamp-3">{description}</p>
+        <div class="mt-auto flex w-full flex-wrap items-center justify-center gap-x-4 gap-y-2 border-t border-ptt-border/60 pt-4 text-sm font-semibold">
+          <a
+            href={profileUrl}
+            aria-label={`${profileLabel} — ${sponsor.data.name}`}
+            data-umami-event="sponsor_meetups_click"
+            data-umami-event-slug={sponsor.id}
+            class="inline-flex min-h-[44px] items-center gap-1 text-ptt-primary hover:underline dark:text-ptt-primary-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary"
+          >
+            {profileLabel}
+            <span aria-hidden="true">→</span>
+          </a>
+          <a
+            href={sponsor.data.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${card.website} — ${sponsor.data.name}`}
+            data-umami-event="sponsor_website_click"
+            data-umami-event-slug={sponsor.id}
+            class="inline-flex min-h-[44px] items-center gap-1 text-ptt-secondary hover:text-ptt hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary"
+          >
+            {card.website}
+            <span aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </>
+    )
+  }
+</article>

--- a/src/components/pages/SponsorDetailPage.astro
+++ b/src/components/pages/SponsorDetailPage.astro
@@ -1,0 +1,374 @@
+---
+/**
+ * PTT v3.0.0 sponsor detail page — the partner profile.
+ *
+ * Product intent: turn a logo into evidence. Everything below the header is
+ * derived from the event side of the graph (`meetups[].sponsors`,
+ * `pereiraTechDays[].sponsors`), so the history is always in sync with the
+ * archive and never hand-maintained on the sponsor entry.
+ */
+
+import type { CollectionEntry } from 'astro:content';
+import EditionCard from '@/components/cards/EditionCard.astro';
+import MeetupCard from '@/components/cards/MeetupCard.astro';
+import JsonLd from '@/components/JsonLd.astro';
+import Badge from '@/components/ui/Badge.astro';
+import Breadcrumbs from '@/components/ui/Breadcrumbs.astro';
+import EmptyState from '@/components/ui/EmptyState.astro';
+import MainLayout from '@/layouts/MainLayout.astro';
+import { SITE_URL } from '@/lib/constances';
+import { getCalendarDateString } from '@/lib/dates';
+import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
+import { getMeetupSlug } from '@/lib/meetup';
+import { isUpcomingEdition } from '@/lib/pereiraTechDay';
+import {
+  getSponsorActivity,
+  SPONSOR_TIER_LABELS,
+  type SponsoredMeetup,
+} from '@/lib/sponsor';
+import { getTranslations } from '@/lib/translations';
+
+interface Props {
+  sponsor: CollectionEntry<'sponsors'>;
+  lang: Language;
+}
+
+const { sponsor, lang } = Astro.props;
+const t = getTranslations(lang);
+const sd = t.sponsorDetail;
+const prefix = getUrlPrefix(lang);
+
+const name = sponsor.data.name;
+const description = tr(sponsor.data.description, lang);
+const logoLight = sponsor.data.logo.light;
+const logoDark = sponsor.data.logo.dark;
+const sameLogo = logoLight === logoDark;
+const isActive = sponsor.data.status === 'active';
+
+const activity = await getSponsorActivity(sponsor);
+
+/** Past meetups grouped by year (descending) for the archive timeline. */
+const pastByYear = ((): { year: number; items: SponsoredMeetup[] }[] => {
+  const byYear = new Map<number, SponsoredMeetup[]>();
+  for (const item of activity.pastMeetups) {
+    if (!byYear.has(item.year)) byYear.set(item.year, []);
+    byYear.get(item.year)?.push(item);
+  }
+  return [...byYear.entries()]
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, items]) => ({ year, items }));
+})();
+
+const stats = [
+  { value: activity.meetupCount, label: sd.stats.meetups },
+  { value: activity.editionCount, label: sd.stats.editions },
+  { value: activity.talkCount, label: sd.stats.talks },
+  { value: activity.speakerCount, label: sd.stats.speakers },
+].filter((s) => s.value > 0);
+
+const breadcrumbs = [
+  { label: sd.breadcrumbHome, href: prefix === '' ? '/' : `${prefix}/` },
+  { label: sd.breadcrumbSponsors, href: `${prefix}/sponsors/` },
+  { label: name },
+];
+
+const metaDescription = sd.metaDescription(name, activity.meetupCount);
+
+const organizationJsonLd: Record<string, unknown> = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name,
+  description,
+  url: sponsor.data.url,
+  logo: logoLight.startsWith('http') ? logoLight : `${SITE_URL}${logoLight}`,
+  mainEntityOfPage: `${SITE_URL}${prefix}/sponsors/${sponsor.id}/`,
+  ...(activity.meetups.length > 0
+    ? {
+        subjectOf: activity.meetups.slice(0, 20).map(({ meetup }) => ({
+          '@type': 'Event',
+          name: tr(meetup.data.title, lang),
+          startDate: getCalendarDateString(meetup.data.date),
+          url: `${SITE_URL}${prefix}/meetups/${getMeetupSlug(meetup)}/`,
+        })),
+      }
+    : {}),
+};
+---
+
+<MainLayout
+  lang={lang}
+  title={`${name} — ${t.sponsorsPage.title}`}
+  description={metaDescription}
+  image={logoLight}
+>
+  <JsonLd data={organizationJsonLd} />
+
+  <article class="bg-ptt-bg">
+    <div class="relative overflow-hidden">
+      <div
+        class="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--ptt-primary)_0%,_transparent_55%)] opacity-[0.07] dark:opacity-[0.12]"
+        aria-hidden="true"
+      >
+      </div>
+
+      <div class="main-container relative pt-12 sm:pt-16 pb-4">
+        <Breadcrumbs items={breadcrumbs} />
+      </div>
+
+      <div class="main-container relative pt-6 pb-12 sm:pb-16">
+        <div class="flex flex-col gap-8 sm:flex-row sm:items-start">
+          <div
+            class="flex h-32 w-full max-w-[16rem] shrink-0 items-center justify-center rounded-2xl bg-ptt-bg-elevated p-6 ring-1 ring-ptt-border sm:w-64"
+          >
+            {
+              sameLogo ? (
+                <img
+                  decoding="async"
+                  src={logoLight}
+                  alt={sponsor.data.logo.alt}
+                  width="208"
+                  height="80"
+                  loading="eager"
+                  class="max-h-20 max-w-full object-contain"
+                />
+              ) : (
+                <>
+                  <img
+                    decoding="async"
+                    src={logoLight}
+                    alt={sponsor.data.logo.alt}
+                    width="208"
+                    height="80"
+                    loading="eager"
+                    class="max-h-20 max-w-full object-contain dark:hidden"
+                  />
+                  <img
+                    decoding="async"
+                    src={logoDark}
+                    alt={sponsor.data.logo.alt}
+                    width="208"
+                    height="80"
+                    loading="eager"
+                    class="hidden max-h-20 max-w-full object-contain dark:block"
+                  />
+                </>
+              )
+            }
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-3">
+              <Badge variant={isActive ? 'announced' : 'completed'}>
+                {isActive ? sd.statusActive : sd.statusPast}
+              </Badge>
+              {
+                activity.firstYear && (
+                  <span class="text-sm text-ptt-secondary">
+                    {sd.sinceLabel(activity.firstYear)}
+                  </span>
+                )
+              }
+            </div>
+            <h1
+              class="mt-3 text-4xl font-bold tracking-tight text-ptt sm:text-5xl"
+            >
+              {name}
+            </h1>
+            <p class="mt-4 max-w-2xl text-lg leading-relaxed text-ptt-secondary">
+              {description}
+            </p>
+
+            <div class="mt-8 flex flex-wrap items-center gap-3">
+              <a
+                href={sponsor.data.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-umami-event="sponsor_website_click"
+                data-umami-event-slug={sponsor.id}
+                class="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-ptt-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-ptt-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark dark:hover:bg-ptt-primary-dark/90"
+              >
+                {sd.websiteLabel}
+                <span aria-hidden="true">↗</span>
+              </a>
+              <a
+                href={`${prefix}/sponsors/`}
+                class="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-ptt-border bg-ptt-bg-elevated px-5 py-2.5 text-sm font-semibold text-ptt transition-colors hover:border-ptt-primary/40 hover:bg-ptt-primary-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:border-white/15 dark:bg-ptt-bg-dark dark:text-white dark:hover:bg-white/10"
+              >
+                {sd.allSponsorsLabel}
+              </a>
+            </div>
+          </div>
+        </div>
+
+        {
+          stats.length > 0 && (
+            <dl class="mt-12 grid grid-cols-2 gap-4 sm:gap-6 lg:grid-cols-4">
+              {stats.map((stat) => (
+                <div class="rounded-2xl bg-ptt-bg-elevated p-5 ring-1 ring-ptt-border">
+                  <dt class="text-xs font-semibold uppercase tracking-[0.14em] text-ptt-secondary">
+                    {stat.label}
+                  </dt>
+                  <dd class="mt-2 text-3xl font-bold tracking-tight text-ptt-primary dark:text-ptt-primary-dark">
+                    {stat.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )
+        }
+      </div>
+    </div>
+
+    {
+      activity.upcomingMeetups.length > 0 && (
+        <section class="bg-ptt-primary-soft/40 py-16 dark:bg-ptt-bg-elevated sm:py-20">
+          <div class="main-container">
+            <h2 class="text-3xl font-bold tracking-tight text-ptt">
+              {sd.upcomingTitle}
+            </h2>
+            <p class="mt-2 text-ptt-secondary">{sd.upcomingSubtitle}</p>
+            <ul class="mt-8 grid list-none gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {activity.upcomingMeetups.map(({ meetup }, index) => (
+                <li>
+                  <MeetupCard
+                    meetup={meetup}
+                    lang={lang}
+                    loading={index < 3 ? 'eager' : 'lazy'}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )
+    }
+
+    {
+      pastByYear.length > 0 && (
+        <section class="py-16 sm:py-20">
+          <div class="main-container">
+            <h2 class="text-3xl font-bold tracking-tight text-ptt">
+              {sd.meetupsTitle}
+            </h2>
+            <p class="mt-2 text-ptt-secondary">{sd.meetupsSubtitle(name)}</p>
+
+            <div class="mt-10 space-y-12">
+              {pastByYear.map(({ year, items }) => (
+                <section aria-labelledby={`sponsored-${year}`}>
+                  <div class="mb-6 flex items-center gap-4">
+                    <h3
+                      id={`sponsored-${year}`}
+                      class="text-xl font-bold tracking-tight text-ptt-primary dark:text-ptt-primary-dark"
+                    >
+                      {year}
+                    </h3>
+                    <span
+                      class="h-px flex-1 bg-ptt-border"
+                      aria-hidden="true"
+                    />
+                    <span class="text-xs font-semibold uppercase tracking-[0.14em] text-ptt-secondary">
+                      {t.sponsorsPage.card.meetupsCount(items.length)}
+                    </span>
+                  </div>
+                  <ul class="grid list-none gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                    {items.map(({ meetup }) => (
+                      <li>
+                        <MeetupCard meetup={meetup} lang={lang} />
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </div>
+        </section>
+      )
+    }
+
+    {
+      activity.editions.length > 0 && (
+        <section class="bg-ptt-primary-soft/40 py-16 dark:bg-ptt-bg-elevated sm:py-20">
+          <div class="main-container">
+            <h2 class="text-3xl font-bold tracking-tight text-ptt">
+              {sd.editionsTitle}
+            </h2>
+            <p class="mt-2 text-ptt-secondary">{sd.editionsSubtitle}</p>
+            <ul class="mt-8 grid list-none gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {activity.editions.map(({ year, tier, edition }) => (
+                <li class="flex flex-col gap-3">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <Badge variant={tier}>
+                      {sd.editionTierLabel(SPONSOR_TIER_LABELS[tier][lang])}
+                    </Badge>
+                    {edition && isUpcomingEdition(edition) && (
+                      <Badge variant="announced">
+                        {sd.editionUpcomingLabel}
+                      </Badge>
+                    )}
+                  </div>
+                  {edition ? (
+                    <EditionCard edition={edition} lang={lang} />
+                  ) : (
+                    <a
+                      href={`${prefix}/pereira-tech-days/${year}/`}
+                      class="flex h-full flex-col justify-center rounded-2xl bg-ptt-bg-elevated p-6 shadow-sm ring-1 ring-ptt-border transition hover:shadow-lg hover:ring-ptt-primary/30 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary"
+                    >
+                      <span class="text-xs font-semibold uppercase tracking-widest text-ptt-primary dark:text-ptt-primary-dark">
+                        {year}
+                      </span>
+                      <span class="mt-2 text-xl font-bold text-ptt">
+                        Pereira Tech Day {year}
+                      </span>
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )
+    }
+
+    {
+      activity.isEmpty && (
+        <section class="py-16 sm:py-20">
+          <div class="main-container">
+            <EmptyState
+              title={sd.emptyTitle}
+              description={sd.emptyDesc}
+              ctaLabel={sd.allSponsorsLabel}
+              ctaHref={`${prefix}/sponsors/`}
+            />
+          </div>
+        </section>
+      )
+    }
+
+    <section class="border-t border-ptt-border bg-ptt-bg py-16 sm:py-20">
+      <div class="main-container">
+        <div
+          class="rounded-2xl bg-ptt-bg-elevated p-8 ring-1 ring-ptt-border sm:p-10"
+        >
+          <h2 class="text-2xl font-bold tracking-tight text-ptt sm:text-3xl">
+            {sd.ctaTitle}
+          </h2>
+          <p class="mt-3 max-w-2xl text-ptt-secondary">{sd.ctaBody}</p>
+          <div class="mt-6 flex flex-wrap gap-3">
+            <a
+              href={`${prefix}/sponsor-us/`}
+              class="inline-flex min-h-[44px] items-center gap-2 rounded-full bg-ptt-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-ptt-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:bg-ptt-primary-dark dark:text-ptt-bg-dark dark:hover:bg-ptt-primary-dark/90"
+            >
+              {sd.sponsorUsLabel}
+            </a>
+            <a
+              href={`${prefix}/contact/`}
+              class="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-ptt-border bg-ptt-bg px-5 py-2.5 text-sm font-semibold text-ptt transition-colors hover:border-ptt-primary/40 hover:bg-ptt-primary-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ptt-primary dark:border-white/15 dark:text-white dark:hover:bg-white/10"
+            >
+              {t.sponsorsPage.contactLabel}
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+</MainLayout>

--- a/src/components/pages/SponsorUsPage.astro
+++ b/src/components/pages/SponsorUsPage.astro
@@ -57,7 +57,9 @@ const t = {
       tier: 'diamond' as const,
       name: lang === 'es' ? 'Diamante' : 'Diamond',
       headline:
-        lang === 'es' ? 'Aliado estratégico anual' : 'Strategic annual partner',
+        lang === 'es'
+          ? 'Patrocinador estratégico anual'
+          : 'Strategic annual partner',
       perks:
         lang === 'es'
           ? [
@@ -78,7 +80,7 @@ const t = {
     {
       tier: 'gold' as const,
       name: lang === 'es' ? 'Oro' : 'Gold',
-      headline: lang === 'es' ? 'Aliado anual' : 'Annual partner',
+      headline: lang === 'es' ? 'Patrocinador anual' : 'Annual partner',
       perks:
         lang === 'es'
           ? [
@@ -116,7 +118,7 @@ const t = {
       name: lang === 'es' ? 'Comunidad' : 'Community',
       headline:
         lang === 'es'
-          ? 'Aliado comunitario sin contraprestación monetaria'
+          ? 'Patrocinador comunitario sin contraprestación monetaria'
           : 'Community ally with non-monetary contribution',
       perks:
         lang === 'es'
@@ -236,7 +238,7 @@ const ctaHref = '#sponsor-form';
   {
     sponsors.length > 0 && (
       <Section
-        eyebrow={lang === 'es' ? 'Aliados actuales' : 'Current partners'}
+        eyebrow={lang === 'es' ? 'Patrocinadores actuales' : 'Current partners'}
         title={t.currentSponsorsTitle}
       >
         <ul class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 list-none">

--- a/src/components/pages/SponsorsPage.astro
+++ b/src/components/pages/SponsorsPage.astro
@@ -10,7 +10,11 @@ import Eyebrow from '@/components/ui/Eyebrow.astro';
 import Section from '@/components/ui/Section.astro';
 import MainLayout from '@/layouts/MainLayout.astro';
 import { getUrlPrefix, type Language } from '@/lib/i18n';
-import { getActiveSponsors, getPastSponsors } from '@/lib/sponsor';
+import {
+  getActiveSponsors,
+  getPastSponsors,
+  getSponsorActivityMap,
+} from '@/lib/sponsor';
 import { getTranslations } from '@/lib/translations';
 
 interface Props {
@@ -24,6 +28,15 @@ const prefix = getUrlPrefix(lang);
 
 const currentSponsors = await getActiveSponsors();
 const pastSponsors = await getPastSponsors();
+
+/**
+ * One pass over meetups + editions for every sponsor, so each card can prove
+ * what the partnership actually funded instead of showing a bare logo.
+ */
+const activityBySponsor = await getSponsorActivityMap([
+  ...currentSponsors,
+  ...pastSponsors,
+]);
 
 const breadcrumbs = [
   { label: sp.breadcrumbHome, href: `${prefix}/` },
@@ -93,6 +106,7 @@ const whyItems = [sp.why.items.meetups, sp.why.items.ptd, sp.why.items.talent];
                 sponsor={sponsor}
                 lang={lang}
                 showTier={false}
+                activity={activityBySponsor.get(sponsor.id)}
                 loading={index < 3 ? 'eager' : 'lazy'}
               />
             </li>
@@ -122,7 +136,13 @@ const whyItems = [sp.why.items.meetups, sp.why.items.ptd, sp.why.items.talent];
         <ul class="grid list-none grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {pastSponsors.map((sponsor) => (
             <li>
-              <SponsorCard sponsor={sponsor} lang={lang} showTier={false} muted />
+              <SponsorCard
+                sponsor={sponsor}
+                lang={lang}
+                showTier={false}
+                activity={activityBySponsor.get(sponsor.id)}
+                muted
+              />
             </li>
           ))}
         </ul>

--- a/src/content/sponsors/ase-utp.yaml
+++ b/src/content/sponsors/ase-utp.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Asociación Egresados Sistemas UTP logo
 url: "https://egresados.utp.edu.co/"
 description:
-  en: Asociación de Egresados de Sistemas, Universidad Tecnológica de Pereira. Active community partner of Pereira Tech Talks — connecting alumni talent with meetups and Pereira Tech Day.
-  es: Asociación de Egresados de Sistemas de la Universidad Tecnológica de Pereira. Aliado activo de Pereira Tech Talks — conecta talento egresado con los meetups y Pereira Tech Day.
+  en: Asociación de Egresados de Sistemas, Universidad Tecnológica de Pereira. Active sponsor of Pereira Tech Talks — connecting alumni talent with meetups and Pereira Tech Day.
+  es: Asociación de Egresados de Sistemas de la Universidad Tecnológica de Pereira. Patrocinador activo de Pereira Tech Talks — conecta talento egresado con los meetups y Pereira Tech Day.
 tier: gold
 sponsoredEditions:
   - year: 2024

--- a/src/content/sponsors/aumentada.yaml
+++ b/src/content/sponsors/aumentada.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Aumentada logo
 url: "https://aumentada.net/"
 description:
-  en: IT solutions from Pereira. Active community partner of Pereira Tech Talks — supporting monthly meetups and the local tech ecosystem.
-  es: Soluciones de TI desde Pereira. Aliado activo de Pereira Tech Talks — apoya los meetups mensuales y el ecosistema tech local.
+  en: IT solutions from Pereira. Active sponsor of Pereira Tech Talks — supporting monthly meetups and the local tech ecosystem.
+  es: Soluciones de TI desde Pereira. Patrocinador activo de Pereira Tech Talks — apoya los meetups mensuales y el ecosistema tech local.
 tier: community
 status: active
 order: 5

--- a/src/content/sponsors/codely.yaml
+++ b/src/content/sponsors/codely.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Codely logo
 url: "https://codely.com/"
 description:
-  en: Training for maintainable, scalable, and testable software. Past community partner of Pereira Tech Talks — supported meetups and the local developer ecosystem.
-  es: Formación para escribir código mantenible, escalable y testable. Aliado comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
+  en: Training for maintainable, scalable, and testable software. Past community sponsor of Pereira Tech Talks — supported meetups and the local developer ecosystem.
+  es: Formación para escribir código mantenible, escalable y testable. Patrocinador comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
 tier: community
 status: past
 order: 7

--- a/src/content/sponsors/cursor.yaml
+++ b/src/content/sponsors/cursor.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Cursor logo
 url: "https://cursor.com/"
 description:
-  en: AI code editor. Past community partner of Pereira Tech Talks — supported the OpenClaw Moltys meetup at UTP (April 2026).
-  es: Editor de código con IA. Aliado comunitario pasado de Pereira Tech Talks — apoyó el meetup OpenClaw Moltys en la UTP (abril 2026).
+  en: AI code editor. Past community sponsor of Pereira Tech Talks — supported the OpenClaw Moltys meetup at UTP (April 2026).
+  es: Editor de código con IA. Patrocinador comunitario pasado de Pereira Tech Talks — apoyó el meetup OpenClaw Moltys en la UTP (abril 2026).
 tier: community
 status: past
 order: 21

--- a/src/content/sponsors/dailybot.yaml
+++ b/src/content/sponsors/dailybot.yaml
@@ -5,8 +5,8 @@ logo:
   alt: DailyBot logo
 url: "https://www.dailybot.com/"
 description:
-  en: AI assistants for high-performing teams. Active community partner of Pereira Tech Talks — supporting meetups and the annual Pereira Tech Day stage.
-  es: Asistentes de IA para equipos de alto desempeño. Aliado activo de Pereira Tech Talks — apoya los meetups y el escenario de Pereira Tech Day.
+  en: AI assistants for high-performing teams. Active sponsor of Pereira Tech Talks — supporting meetups and the annual Pereira Tech Day stage.
+  es: Asistentes de IA para equipos de alto desempeño. Patrocinador activo de Pereira Tech Talks — apoya los meetups y el escenario de Pereira Tech Day.
 tier: silver
 sponsoredEditions:
   - year: 2024

--- a/src/content/sponsors/factored.yaml
+++ b/src/content/sponsors/factored.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Factored logo
 url: "https://www.factored.ai/"
 description:
-  en: Specialized AI, ML, and data engineering teams. Past community partner of Pereira Tech Talks — supported meetups and the local developer ecosystem.
-  es: Equipos especializados en IA, ML e ingeniería de datos. Aliado comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
+  en: Specialized AI, ML, and data engineering teams. Past community sponsor of Pereira Tech Talks — supported meetups and the local developer ecosystem.
+  es: Equipos especializados en IA, ML e ingeniería de datos. Patrocinador comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
 tier: community
 status: past
 order: 8

--- a/src/content/sponsors/github.yaml
+++ b/src/content/sponsors/github.yaml
@@ -5,8 +5,8 @@ logo:
   alt: GitHub logo
 url: "https://github.com/"
 description:
-  en: The home for software collaboration. Active community partner of Pereira Tech Talks and gold sponsor of Pereira Tech Day 2026.
-  es: El hogar de la colaboración en software. Aliado activo de Pereira Tech Talks y patrocinador oro de Pereira Tech Day 2026.
+  en: The home for software collaboration. Active sponsor of Pereira Tech Talks and gold-tier sponsor of Pereira Tech Day 2026.
+  es: El hogar de la colaboración en software. Patrocinador activo de Pereira Tech Talks y de Pereira Tech Day 2026 en categoría oro.
 tier: gold
 sponsoredEditions:
   - year: 2024

--- a/src/content/sponsors/rocka.yaml
+++ b/src/content/sponsors/rocka.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Rocka logo
 url: "https://www.rocka.co/"
 description:
-  en: Fractional CTO/CPO and tech venture builder. Past community partner of Pereira Tech Talks — supported meetups and the local developer ecosystem.
-  es: CTO/CPO fraccional y venture builder tecnológico. Aliado comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
+  en: Fractional CTO/CPO and tech venture builder. Past community sponsor of Pereira Tech Talks — supported meetups and the local developer ecosystem.
+  es: CTO/CPO fraccional y venture builder tecnológico. Patrocinador comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
 tier: community
 status: past
 order: 22

--- a/src/content/sponsors/source-meridian.yaml
+++ b/src/content/sponsors/source-meridian.yaml
@@ -6,7 +6,7 @@ logo:
 url: "https://sourcemeridian.com/"
 description:
   en: Software product partner. Sponsor of Pereira Tech Day 2024 (gold tier).
-  es: Aliado de productos de software. Patrocinador de Pereira Tech Day 2024 (oro).
+  es: Compañía de productos de software. Patrocinador de Pereira Tech Day 2024 (oro).
 tier: gold
 sponsoredEditions:
   - year: 2024

--- a/src/content/sponsors/unity.yaml
+++ b/src/content/sponsors/unity.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Unity logo
 url: "https://unity.com/"
 description:
-  en: Real-time 3D platform for games and interactive experiences. Past community partner of Pereira Tech Talks — supported meetups and the local developer ecosystem.
-  es: Plataforma 3D en tiempo real para juegos y experiencias interactivas. Aliado comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
+  en: Real-time 3D platform for games and interactive experiences. Past community sponsor of Pereira Tech Talks — supported meetups and the local developer ecosystem.
+  es: Plataforma 3D en tiempo real para juegos y experiencias interactivas. Patrocinador comunitario pasado de Pereira Tech Talks — apoyó los meetups y el ecosistema local de developers.
 tier: community
 status: past
 order: 9

--- a/src/content/sponsors/universidad-catolica-de-pereira.yaml
+++ b/src/content/sponsors/universidad-catolica-de-pereira.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Universidad Católica de Pereira logo
 url: "https://www.ucp.edu.co/"
 description:
-  en: Higher-education partner in Pereira. Past community partner of Pereira Tech Talks — hosted meetups and opened campus spaces to the local tech community.
-  es: Aliado de educación superior en Pereira. Aliado comunitario pasado de Pereira Tech Talks — recibió meetups y abrió espacios del campus a la comunidad tech local.
+  en: Higher-education partner in Pereira. Past community sponsor of Pereira Tech Talks — hosted meetups and opened campus spaces to the local tech community.
+  es: Institución de educación superior en Pereira. Patrocinador comunitario pasado de Pereira Tech Talks — recibió meetups y abrió espacios del campus a la comunidad tech local.
 tier: community
 status: past
 order: 4

--- a/src/content/sponsors/veritran.yaml
+++ b/src/content/sponsors/veritran.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Veritran logo
 url: "https://veritran.com/"
 description:
-  en: Low-code technology for digital banking and financial applications. Active community partner of Pereira Tech Talks and gold sponsor of Pereira Tech Day 2026.
-  es: Tecnología low-code para banca digital y aplicaciones financieras. Aliado activo de Pereira Tech Talks y patrocinador oro de Pereira Tech Day 2026.
+  en: Low-code technology for digital banking and financial applications. Active sponsor of Pereira Tech Talks and gold-tier sponsor of Pereira Tech Day 2026.
+  es: Tecnología low-code para banca digital y aplicaciones financieras. Patrocinador activo de Pereira Tech Talks y de Pereira Tech Day 2026 en categoría oro.
 tier: gold
 sponsoredEditions:
   - year: 2026

--- a/src/content/sponsors/vuetify.yaml
+++ b/src/content/sponsors/vuetify.yaml
@@ -5,8 +5,8 @@ logo:
   alt: Vuetify logo
 url: "https://vuetifyjs.com/"
 description:
-  en: Vue component framework. Past community partner of Pereira Tech Talks — supported the local Vue ecosystem and meetup stage.
-  es: Framework de componentes Vue. Aliado comunitario pasado de Pereira Tech Talks — apoyó el ecosistema Vue local y el escenario de meetups.
+  en: Vue component framework. Past community sponsor of Pereira Tech Talks — supported the local Vue ecosystem and meetup stage.
+  es: Framework de componentes Vue. Patrocinador comunitario pasado de Pereira Tech Talks — apoyó el ecosistema Vue local y el escenario de meetups.
 tier: community
 status: past
 order: 3

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -1,6 +1,17 @@
 import { type CollectionEntry, getCollection } from 'astro:content';
 
+import { getCalendarYear, getTodayInSiteTimezone } from '@/lib/dates';
+import {
+  getMeetups,
+  type Meetup,
+  type MeetupLifecycleStatus,
+  resolveMeetupStatus,
+} from '@/lib/meetup';
+import { getEditions, type PereiraTechDay } from '@/lib/pereiraTechDay';
+
 export type Sponsor = CollectionEntry<'sponsors'>;
+
+export type SponsorTier = Sponsor['data']['tier'];
 
 const tierOrder: Record<Sponsor['data']['tier'], number> = {
   diamond: 0,
@@ -8,6 +19,18 @@ const tierOrder: Record<Sponsor['data']['tier'], number> = {
   silver: 2,
   bronze: 3,
   community: 4,
+};
+
+/** Singular, human-facing tier names. Plural section headings live in i18n. */
+export const SPONSOR_TIER_LABELS: Record<
+  SponsorTier,
+  { en: string; es: string }
+> = {
+  diamond: { en: 'Diamond', es: 'Diamante' },
+  gold: { en: 'Gold', es: 'Oro' },
+  silver: { en: 'Silver', es: 'Plata' },
+  bronze: { en: 'Bronze', es: 'Bronce' },
+  community: { en: 'Community', es: 'Comunidad' },
 };
 
 const sortByTierThenOrder = (a: Sponsor, b: Sponsor): number => {
@@ -49,6 +72,13 @@ export const getPastSponsors = async (): Promise<Sponsor[]> => {
   return sortSponsorsByOrder(filterSponsorsByStatus(all, 'past'));
 };
 
+export const getSponsorBySlug = async (
+  slug: string
+): Promise<Sponsor | undefined> => {
+  const all = await getSponsors();
+  return all.find((s) => s.id === slug);
+};
+
 export const getSponsorsByTier = async (
   tier: Sponsor['data']['tier']
 ): Promise<Sponsor[]> => {
@@ -63,6 +93,183 @@ export const getSponsorsByEdition = async (
   return all
     .filter((s) => s.data.sponsoredEditions.some((e) => e.year === year))
     .sort(sortByTierThenOrder);
+};
+
+/* ------------------------------------------------------------------ *
+ * Sponsor activity — "which meetups did this partner back?"
+ *
+ * Source of truth is the *event* side (a meetup declares its sponsors), so a
+ * sponsor's history is always derived, never hand-maintained on the sponsor
+ * YAML. `sponsoredEditions` is only used as a fallback for Pereira Tech Day
+ * years that have no entry in the `pereiraTechDays` collection yet.
+ * ------------------------------------------------------------------ */
+
+export interface SponsoredMeetup {
+  meetup: Meetup;
+  /** Tier declared by that meetup for this sponsor (may differ from default). */
+  tier: SponsorTier;
+  status: MeetupLifecycleStatus;
+  upcoming: boolean;
+  year: number;
+}
+
+export interface SponsoredEdition {
+  year: number;
+  tier: SponsorTier;
+  /** Present when the year exists in the `pereiraTechDays` collection. */
+  edition?: PereiraTechDay;
+}
+
+export interface SponsorActivity {
+  /** All sponsored meetups, newest first. */
+  meetups: SponsoredMeetup[];
+  upcomingMeetups: SponsoredMeetup[];
+  pastMeetups: SponsoredMeetup[];
+  editions: SponsoredEdition[];
+  meetupCount: number;
+  editionCount: number;
+  /** Distinct talks programmed across the sponsored meetups. */
+  talkCount: number;
+  /** Distinct speakers who took the stage at the sponsored meetups. */
+  speakerCount: number;
+  firstYear: number | null;
+  lastYear: number | null;
+  /** True when the partner has nothing linked yet (logo-only entry). */
+  isEmpty: boolean;
+}
+
+export const EMPTY_SPONSOR_ACTIVITY: SponsorActivity = {
+  meetups: [],
+  upcomingMeetups: [],
+  pastMeetups: [],
+  editions: [],
+  meetupCount: 0,
+  editionCount: 0,
+  talkCount: 0,
+  speakerCount: 0,
+  firstYear: null,
+  lastYear: null,
+  isEmpty: true,
+};
+
+/**
+ * Pure builder — resolves everything a sponsor detail page needs from the
+ * already-loaded meetup and edition collections.
+ */
+export const buildSponsorActivity = (
+  sponsorSlug: string,
+  meetups: Meetup[],
+  editions: PereiraTechDay[],
+  sponsoredEditions: Sponsor['data']['sponsoredEditions'] = [],
+  todayInTz: string = getTodayInSiteTimezone()
+): SponsorActivity => {
+  const sponsored: SponsoredMeetup[] = [];
+  const talks = new Set<string>();
+  const speakers = new Set<string>();
+
+  for (const meetup of meetups) {
+    const ref = meetup.data.sponsors?.find((s) => s.slug === sponsorSlug);
+    if (!ref) continue;
+    const status = resolveMeetupStatus(meetup, todayInTz);
+    sponsored.push({
+      meetup,
+      tier: ref.tier,
+      status,
+      upcoming: status === 'announced' || status === 'rsvp-open',
+      year: getCalendarYear(meetup.data.date),
+    });
+    for (const talk of meetup.data.talks ?? []) talks.add(talk);
+    for (const speaker of meetup.data.speakers ?? []) speakers.add(speaker);
+  }
+
+  sponsored.sort(
+    (a, b) => b.meetup.data.date.getTime() - a.meetup.data.date.getTime()
+  );
+
+  // Editions: collection first (authoritative tier), then any orphan year
+  // still declared on the sponsor YAML.
+  const editionsByYear = new Map<number, SponsoredEdition>();
+  for (const edition of editions) {
+    const ref = edition.data.sponsors?.find((s) => s.slug === sponsorSlug);
+    if (!ref) continue;
+    editionsByYear.set(edition.data.year, {
+      year: edition.data.year,
+      tier: ref.tier,
+      edition,
+    });
+  }
+  for (const ref of sponsoredEditions) {
+    if (editionsByYear.has(ref.year)) continue;
+    editionsByYear.set(ref.year, { year: ref.year, tier: ref.tier });
+  }
+  const editionList = [...editionsByYear.values()].sort(
+    (a, b) => b.year - a.year
+  );
+
+  const years = [
+    ...sponsored.map((s) => s.year),
+    ...editionList.map((e) => e.year),
+  ];
+
+  const upcomingMeetups = sponsored.filter((s) => s.upcoming);
+  const pastMeetups = sponsored.filter((s) => !s.upcoming);
+
+  return {
+    meetups: sponsored,
+    upcomingMeetups,
+    pastMeetups,
+    editions: editionList,
+    meetupCount: sponsored.length,
+    editionCount: editionList.length,
+    talkCount: talks.size,
+    speakerCount: speakers.size,
+    firstYear: years.length > 0 ? Math.min(...years) : null,
+    lastYear: years.length > 0 ? Math.max(...years) : null,
+    isEmpty: sponsored.length === 0 && editionList.length === 0,
+  };
+};
+
+/** Sponsored meetups for one sponsor slug, newest first. */
+export const getMeetupsBySponsor = async (
+  sponsorSlug: string
+): Promise<SponsoredMeetup[]> => {
+  const [meetups, editions] = await Promise.all([getMeetups(), getEditions()]);
+  return buildSponsorActivity(sponsorSlug, meetups, editions).meetups;
+};
+
+export const getSponsorActivity = async (
+  sponsor: Sponsor
+): Promise<SponsorActivity> => {
+  const [meetups, editions] = await Promise.all([getMeetups(), getEditions()]);
+  return buildSponsorActivity(
+    sponsor.id,
+    meetups,
+    editions,
+    sponsor.data.sponsoredEditions
+  );
+};
+
+/**
+ * Activity for many sponsors in a single pass over the collections — used by
+ * the `/sponsors` grid so each card can show its own counters.
+ */
+export const getSponsorActivityMap = async (
+  sponsors: Sponsor[]
+): Promise<Map<string, SponsorActivity>> => {
+  const [meetups, editions] = await Promise.all([getMeetups(), getEditions()]);
+  const today = getTodayInSiteTimezone();
+  return new Map(
+    sponsors.map((sponsor) => [
+      sponsor.id,
+      buildSponsorActivity(
+        sponsor.id,
+        meetups,
+        editions,
+        sponsor.data.sponsoredEditions,
+        today
+      ),
+    ])
+  );
 };
 
 export interface EditionSponsor {

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -576,10 +576,10 @@ If you are looking for people to grow with, a stage for your first talk, or a co
   sponsorsPage: {
     title: 'Sponsors',
     description:
-      'Current and past partners of Pereira Tech Talks — companies and organizations that sustain meetups, Pereira Tech Day, and community programs in Pereira.',
+      'Current and past sponsors of Pereira Tech Talks — companies and organizations that sustain meetups, Pereira Tech Day, and community programs in Pereira.',
     eyebrow: 'Current sponsors',
     intro: (count) =>
-      `${count} active partners help with venues, logistics, and the stage. Per-edition sponsorship tiers live on each Pereira Tech Day page — not here.`,
+      `${count} active sponsors help with venues, logistics, and the stage. Per-edition sponsorship tiers live on each Pereira Tech Day page — not here.`,
     currentTitle: 'Current sponsors',
     currentIntro:
       'Who stands with Pereira Tech Talks today — monthly meetups and the annual conference.',
@@ -598,7 +598,7 @@ If you are looking for people to grow with, a stage for your first talk, or a co
       items: {
         meetups: {
           title: 'Real meetups',
-          body: 'Venue, snacks, and monthly continuity — the community needs partners who make each talk night possible.',
+          body: 'Venue, snacks, and monthly continuity — the community needs sponsors who make each talk night possible.',
         },
         ptd: {
           title: 'Pereira Tech Day',
@@ -615,8 +615,52 @@ If you are looking for people to grow with, a stage for your first talk, or a co
       gold: 'Gold sponsors',
       silver: 'Silver sponsors',
       bronze: 'Bronze sponsors',
-      community: 'Community partners',
+      community: 'Community sponsors',
     },
+    card: {
+      meetupsCount: (count) =>
+        count === 1 ? '1 sponsored meetup' : `${count} sponsored meetups`,
+      viewSponsoredMeetups: 'View sponsored meetups',
+      website: 'Website',
+    },
+  },
+
+  sponsorDetail: {
+    breadcrumbHome: 'Home',
+    breadcrumbSponsors: 'Sponsors',
+    metaDescription: (name, meetups) =>
+      meetups > 0
+        ? `${name} has sponsored ${meetups} Pereira Tech Talks ${meetups === 1 ? 'meetup' : 'meetups'}. Browse the full history of gatherings and editions they made possible.`
+        : `${name} is a Pereira Tech Talks sponsor. See their role in the Pereira tech community and the gatherings they support.`,
+    statusActive: 'Current sponsor',
+    statusPast: 'Past sponsor',
+    sinceLabel: (year) => `Backing the community since ${year}`,
+    websiteLabel: 'Visit website',
+    allSponsorsLabel: 'All sponsors',
+    sponsorUsLabel: 'Become a sponsor',
+    stats: {
+      meetups: 'Sponsored meetups',
+      editions: 'PTD editions',
+      talks: 'Talks enabled',
+      speakers: 'Speakers on stage',
+    },
+    upcomingTitle: 'Upcoming sponsored meetups',
+    upcomingSubtitle:
+      'Already-scheduled gatherings backed by this sponsor. Come join us.',
+    meetupsTitle: 'Sponsored meetups',
+    meetupsSubtitle: (name) =>
+      `Every talk night ${name} helped sustain, from the most recent to the first.`,
+    editionsTitle: 'Pereira Tech Day editions',
+    editionsSubtitle:
+      'The annual community conference and each sponsor’s tier in that edition.',
+    editionUpcomingLabel: 'Upcoming edition',
+    editionTierLabel: (tier) => `${tier} sponsor`,
+    emptyTitle: 'No linked gatherings yet',
+    emptyDesc:
+      'This sponsor has no meetups or editions on record yet. We are still filling in the community archive, one chapter at a time.',
+    ctaTitle: 'Want to show up here?',
+    ctaBody:
+      'Sponsoring Pereira Tech Talks means funding venue, logistics, and stage for the Risaralda tech community. Tell us what you have in mind.',
   },
 
   contributorsPage: {

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -577,10 +577,10 @@ Si buscas gente con quien crecer, un escenario para tu primera charla o una comu
   sponsorsPage: {
     title: 'Patrocinadores',
     description:
-      'Aliados actuales y anteriores de Pereira Tech Talks — empresas y organizaciones que sostienen meetups, Pereira Tech Day y los programas de la comunidad en Pereira.',
+      'Patrocinadores actuales y anteriores de Pereira Tech Talks — empresas y organizaciones que sostienen meetups, Pereira Tech Day y los programas de la comunidad en Pereira.',
     eyebrow: 'Patrocinadores Actuales',
     intro: (count) =>
-      `${count} aliados activos sostienen venues, logística y escenario. Las categorías de patrocinio por edición viven en cada Pereira Tech Day.`,
+      `${count} patrocinadores activos sostienen venues, logística y escenario. Las categorías de patrocinio por edición viven en cada Pereira Tech Day.`,
     currentTitle: 'Patrocinadores actuales',
     currentIntro:
       'Quienes acompañan a Pereira Tech Talks hoy — meetups mensuales y la conferencia anual.',
@@ -599,7 +599,7 @@ Si buscas gente con quien crecer, un escenario para tu primera charla o una comu
       items: {
         meetups: {
           title: 'Meetups reales',
-          body: 'Venue, snacks y continuidad mensual — la comunidad necesita aliados que hagan posible cada noche de charlas.',
+          body: 'Venue, snacks y continuidad mensual — la comunidad necesita patrocinadores que hagan posible cada noche de charlas.',
         },
         ptd: {
           title: 'Pereira Tech Day',
@@ -616,8 +616,52 @@ Si buscas gente con quien crecer, un escenario para tu primera charla o una comu
       gold: 'Patrocinadores oro',
       silver: 'Patrocinadores plata',
       bronze: 'Patrocinadores bronce',
-      community: 'Aliados comunitarios',
+      community: 'Patrocinadores comunitarios',
     },
+    card: {
+      meetupsCount: (count) =>
+        count === 1 ? '1 meetup patrocinado' : `${count} meetups patrocinados`,
+      viewSponsoredMeetups: 'Ver meetups patrocinados',
+      website: 'Sitio web',
+    },
+  },
+
+  sponsorDetail: {
+    breadcrumbHome: 'Inicio',
+    breadcrumbSponsors: 'Patrocinadores',
+    metaDescription: (name, meetups) =>
+      meetups > 0
+        ? `${name} ha patrocinado ${meetups} ${meetups === 1 ? 'meetup' : 'meetups'} de Pereira Tech Talks. Revisa el historial completo de encuentros y ediciones que hizo posibles.`
+        : `${name} es patrocinador de Pereira Tech Talks. Conoce su rol en la comunidad tecnológica de Pereira y los encuentros que acompaña.`,
+    statusActive: 'Patrocinador actual',
+    statusPast: 'Patrocinador anterior',
+    sinceLabel: (year) => `Acompañando a la comunidad desde ${year}`,
+    websiteLabel: 'Visitar sitio web',
+    allSponsorsLabel: 'Todos los patrocinadores',
+    sponsorUsLabel: 'Quiero patrocinar',
+    stats: {
+      meetups: 'Meetups patrocinados',
+      editions: 'Ediciones de PTD',
+      talks: 'Charlas impulsadas',
+      speakers: 'Ponentes en escena',
+    },
+    upcomingTitle: 'Próximos meetups patrocinados',
+    upcomingSubtitle:
+      'Encuentros ya agendados que cuentan con este patrocinador. Te esperamos.',
+    meetupsTitle: 'Meetups patrocinados',
+    meetupsSubtitle: (name) =>
+      `Cada noche de charlas que ${name} ayudó a sostener, del más reciente al primero.`,
+    editionsTitle: 'Ediciones de Pereira Tech Day',
+    editionsSubtitle:
+      'La conferencia anual de la comunidad y la categoría de patrocinio en cada edición.',
+    editionUpcomingLabel: 'Próxima edición',
+    editionTierLabel: (tier) => `Patrocinador ${tier}`,
+    emptyTitle: 'Aún no hay encuentros enlazados',
+    emptyDesc:
+      'Este patrocinador todavía no tiene meetups ni ediciones registradas en el archivo. Estamos completando la historia de la comunidad poco a poco.',
+    ctaTitle: '¿Quieres aparecer aquí?',
+    ctaBody:
+      'Patrocinar Pereira Tech Talks es sostener venue, logística y escenario para la comunidad tech de Risaralda. Cuéntanos qué tienes en mente.',
   },
 
   contributorsPage: {

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -451,6 +451,44 @@ export interface SiteTranslations {
       bronze: string;
       community: string;
     };
+    /** Sponsor card affordances. */
+    card: {
+      /** Also used as the per-year counter on the sponsor profile timeline. */
+      meetupsCount: (count: number) => string;
+      viewSponsoredMeetups: string;
+      website: string;
+    };
+  };
+
+  // Sponsor detail page (/sponsors/{slug})
+  sponsorDetail: {
+    breadcrumbHome: string;
+    breadcrumbSponsors: string;
+    metaDescription: (name: string, meetups: number) => string;
+    statusActive: string;
+    statusPast: string;
+    sinceLabel: (year: number) => string;
+    websiteLabel: string;
+    allSponsorsLabel: string;
+    sponsorUsLabel: string;
+    stats: {
+      meetups: string;
+      editions: string;
+      talks: string;
+      speakers: string;
+    };
+    upcomingTitle: string;
+    upcomingSubtitle: string;
+    meetupsTitle: string;
+    meetupsSubtitle: (name: string) => string;
+    editionsTitle: string;
+    editionsSubtitle: string;
+    editionUpcomingLabel: string;
+    editionTierLabel: (tier: string) => string;
+    emptyTitle: string;
+    emptyDesc: string;
+    ctaTitle: string;
+    ctaBody: string;
   };
 
   contributorsPage: {

--- a/src/pages/en/sponsors/[slug].astro
+++ b/src/pages/en/sponsors/[slug].astro
@@ -1,0 +1,16 @@
+---
+import SponsorDetailPage from '@/components/pages/SponsorDetailPage.astro';
+import { getSponsors } from '@/lib/sponsor';
+
+export async function getStaticPaths() {
+  const sponsors = await getSponsors();
+  return sponsors.map((sponsor) => ({
+    params: { slug: sponsor.id },
+    props: { sponsor },
+  }));
+}
+
+const { sponsor } = Astro.props;
+---
+
+<SponsorDetailPage sponsor={sponsor} lang="en" />

--- a/src/pages/en/sponsors/[slug].md.ts
+++ b/src/pages/en/sponsors/[slug].md.ts
@@ -1,0 +1,85 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { SITE_URL } from '@/lib/constances';
+import { getCalendarDateString } from '@/lib/dates';
+
+import {
+  resolveI18n,
+  serializeGenericToMarkdown,
+} from '@/lib/markdown-for-agents';
+import { getMeetupSlug } from '@/lib/meetup';
+import {
+  getSponsorActivity,
+  getSponsors,
+  SPONSOR_TIER_LABELS,
+  type Sponsor,
+} from '@/lib/sponsor';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const sponsors = await getSponsors();
+  return sponsors.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const lang = 'en';
+  const { entry } = props as { entry: Sponsor };
+  const description = resolveI18n(entry.data.description, lang);
+  const activity = await getSponsorActivity(entry);
+
+  const metadata: Array<[string, string]> = [
+    [
+      'Status',
+      entry.data.status === 'active' ? 'Current sponsor' : 'Past sponsor',
+    ],
+    ['Website', entry.data.url],
+    ['Sponsored meetups', String(activity.meetupCount)],
+    ['Pereira Tech Day editions', String(activity.editionCount)],
+  ];
+  if (activity.firstYear && activity.lastYear) {
+    metadata.push([
+      'Years of support',
+      activity.firstYear === activity.lastYear
+        ? String(activity.firstYear)
+        : `${activity.firstYear}–${activity.lastYear}`,
+    ]);
+  }
+
+  const sections = [];
+  if (activity.meetups.length > 0) {
+    sections.push({
+      heading: 'Sponsored meetups',
+      lines: activity.meetups.map(({ meetup }) => {
+        const title = resolveI18n(meetup.data.title, lang);
+        const date = getCalendarDateString(meetup.data.date);
+        return `- ${date} — [${title}](${SITE_URL}/en/meetups/${getMeetupSlug(meetup)})`;
+      }),
+    });
+  }
+  if (activity.editions.length > 0) {
+    sections.push({
+      heading: 'Pereira Tech Day editions',
+      lines: activity.editions.map(
+        ({ year, tier }) =>
+          `- [Pereira Tech Day ${year}](${SITE_URL}/en/pereira-tech-days/${year}) — ${SPONSOR_TIER_LABELS[tier].en.toLowerCase()} sponsor`
+      ),
+    });
+  }
+
+  const markdown = serializeGenericToMarkdown({
+    title: `${entry.data.name} — Pereira Tech Talks sponsor`,
+    description,
+    lang,
+    canonical: `${SITE_URL}/en/sponsors/${entry.id}`,
+    metadata,
+    sections,
+  });
+
+  return new Response(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/en/sponsors/index.md.ts
+++ b/src/pages/en/sponsors/index.md.ts
@@ -5,34 +5,49 @@ import {
   resolveI18n,
   serializeGenericToMarkdown,
 } from '@/lib/markdown-for-agents';
-import { getActiveSponsors, getPastSponsors } from '@/lib/sponsor';
+import {
+  getActiveSponsors,
+  getPastSponsors,
+  getSponsorActivityMap,
+} from '@/lib/sponsor';
 
 export const GET: APIRoute = async () => {
   const lang = 'en';
   const current = await getActiveSponsors();
   const past = await getPastSponsors();
+  const activity = await getSponsorActivityMap([...current, ...past]);
 
   const toLines = (
     list: Awaited<ReturnType<typeof getActiveSponsors>>
   ): string[] =>
     list.map((s) => {
       const description = resolveI18n(s.data.description, lang);
-      return `- [${s.data.name}](${s.data.url}) — ${description}`;
+      const stats = activity.get(s.id);
+      const counters = [
+        stats?.meetupCount
+          ? `${stats.meetupCount} sponsored meetups`
+          : undefined,
+        stats?.editionCount ? `${stats.editionCount} PTD editions` : undefined,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      const profile = `${SITE_URL}/en/sponsors/${s.id}`;
+      return `- [${s.data.name}](${profile}) — ${description}${counters ? ` (${counters})` : ''} · [website](${s.data.url})`;
     });
 
   const markdown = serializeGenericToMarkdown({
     title: 'Sponsors — Pereira Tech Talks',
     description:
-      'Current and past partners of Pereira Tech Talks. Per-edition tiers (gold, silver, etc.) live on each Pereira Tech Day page — not on this community directory.',
+      'Current and past sponsors of Pereira Tech Talks. Per-edition tiers (gold, silver, etc.) live on each Pereira Tech Day page — not on this community directory.',
     lang,
     canonical: `${SITE_URL}/en/sponsors`,
     metadata: [
-      ['Current partners', String(current.length)],
-      ['Past partners', String(past.length)],
+      ['Current sponsors', String(current.length)],
+      ['Past sponsors', String(past.length)],
     ],
     sections: [
-      { heading: 'Current partners', lines: toLines(current) },
-      { heading: 'Past partners', lines: toLines(past) },
+      { heading: 'Current sponsors', lines: toLines(current) },
+      { heading: 'Past sponsors', lines: toLines(past) },
     ],
   });
 

--- a/src/pages/sponsor-us.md.ts
+++ b/src/pages/sponsor-us.md.ts
@@ -30,8 +30,8 @@ export const GET: APIRoute = () => {
       {
         heading: 'Niveles de patrocinio',
         lines: [
-          '- **Diamante** — Aliado estratégico anual. Co-branding en PTD y meetups del año, spot de keynote, menciones mensuales, acceso al hiring pool, logo en banner principal.',
-          '- **Oro** — Aliado anual. Logo en el programa de PTD, una charla técnica patrocinada al año, menciones en 6+ meetups, acceso al hiring pool.',
+          '- **Diamante** — Patrocinador estratégico anual. Co-branding en PTD y meetups del año, spot de keynote, menciones mensuales, acceso al hiring pool, logo en banner principal.',
+          '- **Oro** — Patrocinador anual. Logo en el programa de PTD, una charla técnica patrocinada al año, menciones en 6+ meetups, acceso al hiring pool.',
           '- **Plata** — Patrocinador puntual. Logo en el evento patrocinado, menciones pre y post, stand opcional.',
           '- **Comunidad** — Aporte no monetario (venues, comida, transporte, becas). Logo en el evento apoyado y reconocimiento en la página de patrocinadores.',
         ],

--- a/src/pages/sponsors/[slug].astro
+++ b/src/pages/sponsors/[slug].astro
@@ -1,0 +1,16 @@
+---
+import SponsorDetailPage from '@/components/pages/SponsorDetailPage.astro';
+import { getSponsors } from '@/lib/sponsor';
+
+export async function getStaticPaths() {
+  const sponsors = await getSponsors();
+  return sponsors.map((sponsor) => ({
+    params: { slug: sponsor.id },
+    props: { sponsor },
+  }));
+}
+
+const { sponsor } = Astro.props;
+---
+
+<SponsorDetailPage sponsor={sponsor} lang="es" />

--- a/src/pages/sponsors/[slug].md.ts
+++ b/src/pages/sponsors/[slug].md.ts
@@ -1,0 +1,87 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { SITE_URL } from '@/lib/constances';
+import { getCalendarDateString } from '@/lib/dates';
+
+import {
+  resolveI18n,
+  serializeGenericToMarkdown,
+} from '@/lib/markdown-for-agents';
+import { getMeetupSlug } from '@/lib/meetup';
+import {
+  getSponsorActivity,
+  getSponsors,
+  SPONSOR_TIER_LABELS,
+  type Sponsor,
+} from '@/lib/sponsor';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const sponsors = await getSponsors();
+  return sponsors.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const lang = 'es';
+  const { entry } = props as { entry: Sponsor };
+  const description = resolveI18n(entry.data.description, lang);
+  const activity = await getSponsorActivity(entry);
+
+  const metadata: Array<[string, string]> = [
+    [
+      'Estado',
+      entry.data.status === 'active'
+        ? 'Patrocinador actual'
+        : 'Patrocinador anterior',
+    ],
+    ['Sitio web', entry.data.url],
+    ['Meetups patrocinados', String(activity.meetupCount)],
+    ['Ediciones de Pereira Tech Day', String(activity.editionCount)],
+  ];
+  if (activity.firstYear && activity.lastYear) {
+    metadata.push([
+      'Años de apoyo',
+      activity.firstYear === activity.lastYear
+        ? String(activity.firstYear)
+        : `${activity.firstYear}–${activity.lastYear}`,
+    ]);
+  }
+
+  const sections = [];
+  if (activity.meetups.length > 0) {
+    sections.push({
+      heading: 'Meetups patrocinados',
+      lines: activity.meetups.map(({ meetup }) => {
+        const title = resolveI18n(meetup.data.title, lang);
+        const date = getCalendarDateString(meetup.data.date);
+        return `- ${date} — [${title}](${SITE_URL}/meetups/${getMeetupSlug(meetup)})`;
+      }),
+    });
+  }
+  if (activity.editions.length > 0) {
+    sections.push({
+      heading: 'Ediciones de Pereira Tech Day',
+      lines: activity.editions.map(
+        ({ year, tier }) =>
+          `- [Pereira Tech Day ${year}](${SITE_URL}/pereira-tech-days/${year}) — patrocinador ${SPONSOR_TIER_LABELS[tier].es.toLowerCase()}`
+      ),
+    });
+  }
+
+  const markdown = serializeGenericToMarkdown({
+    title: `${entry.data.name} — Patrocinador de Pereira Tech Talks`,
+    description,
+    lang,
+    canonical: `${SITE_URL}/sponsors/${entry.id}`,
+    metadata,
+    sections,
+  });
+
+  return new Response(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/sponsors/index.md.ts
+++ b/src/pages/sponsors/index.md.ts
@@ -5,34 +5,49 @@ import {
   resolveI18n,
   serializeGenericToMarkdown,
 } from '@/lib/markdown-for-agents';
-import { getActiveSponsors, getPastSponsors } from '@/lib/sponsor';
+import {
+  getActiveSponsors,
+  getPastSponsors,
+  getSponsorActivityMap,
+} from '@/lib/sponsor';
 
 export const GET: APIRoute = async () => {
   const lang = 'es';
   const current = await getActiveSponsors();
   const past = await getPastSponsors();
+  const activity = await getSponsorActivityMap([...current, ...past]);
 
   const toLines = (
     list: Awaited<ReturnType<typeof getActiveSponsors>>
   ): string[] =>
     list.map((s) => {
       const description = resolveI18n(s.data.description, lang);
-      return `- [${s.data.name}](${s.data.url}) — ${description}`;
+      const stats = activity.get(s.id);
+      const counters = [
+        stats?.meetupCount
+          ? `${stats.meetupCount} meetups patrocinados`
+          : undefined,
+        stats?.editionCount ? `${stats.editionCount} ediciones PTD` : undefined,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      const profile = `${SITE_URL}/sponsors/${s.id}`;
+      return `- [${s.data.name}](${profile}) — ${description}${counters ? ` (${counters})` : ''} · [sitio web](${s.data.url})`;
     });
 
   const markdown = serializeGenericToMarkdown({
     title: 'Patrocinadores — Pereira Tech Talks',
     description:
-      'Aliados actuales y anteriores de Pereira Tech Talks. Las categorías por edición (oro, plata, etc.) viven en cada Pereira Tech Day, no en este directorio comunitario.',
+      'Patrocinadores actuales y anteriores de Pereira Tech Talks. Las categorías por edición (oro, plata, etc.) viven en cada Pereira Tech Day, no en este directorio comunitario.',
     lang,
     canonical: `${SITE_URL}/sponsors`,
     metadata: [
-      ['Aliados actuales', String(current.length)],
-      ['Aliados anteriores', String(past.length)],
+      ['Patrocinadores actuales', String(current.length)],
+      ['Patrocinadores anteriores', String(past.length)],
     ],
     sections: [
-      { heading: 'Aliados actuales', lines: toLines(current) },
-      { heading: 'Aliados anteriores', lines: toLines(past) },
+      { heading: 'Patrocinadores actuales', lines: toLines(current) },
+      { heading: 'Patrocinadores anteriores', lines: toLines(past) },
     ],
   });
 

--- a/tests/unit/lib/sponsor.test.ts
+++ b/tests/unit/lib/sponsor.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Meetup } from '@/lib/meetup';
+import type { PereiraTechDay } from '@/lib/pereiraTechDay';
 import type { Sponsor } from '@/lib/sponsor';
 import {
+  buildSponsorActivity,
   filterSponsorsByStatus,
   sortSponsors,
   sortSponsorsByOrder,
@@ -59,5 +62,167 @@ describe('sponsor helpers', () => {
 
     expect(active.map((s) => s.id)).toEqual(['active-one']);
     expect(past.map((s) => s.id)).toEqual(['past-one']);
+  });
+});
+
+const TODAY = '2026-08-08';
+
+const makeMeetup = (
+  id: string,
+  date: string,
+  sponsors: { slug: string; tier: Sponsor['data']['tier'] }[],
+  extra: { talks?: string[]; speakers?: string[]; status?: string } = {}
+): Meetup =>
+  ({
+    id,
+    collection: 'meetups',
+    data: {
+      title: { en: id, es: id },
+      description: { en: id, es: id },
+      date: new Date(`${date}T00:00:00Z`),
+      sponsors,
+      talks: extra.talks ?? [],
+      speakers: extra.speakers ?? [],
+      status: extra.status ?? 'announced',
+      draft: false,
+    },
+  }) as unknown as Meetup;
+
+const makeEdition = (
+  year: number,
+  sponsors: { slug: string; tier: Sponsor['data']['tier'] }[]
+): PereiraTechDay =>
+  ({
+    id: String(year),
+    collection: 'pereiraTechDays',
+    data: { year, sponsors },
+  }) as unknown as PereiraTechDay;
+
+describe('buildSponsorActivity', () => {
+  const meetups = [
+    makeMeetup(
+      '2024-03-20_alpha',
+      '2024-03-20',
+      [{ slug: 'dailybot', tier: 'community' }],
+      { talks: ['talk-a'], speakers: ['ana'] }
+    ),
+    makeMeetup(
+      '2025-04-24_beta',
+      '2025-04-24',
+      [
+        { slug: 'dailybot', tier: 'community' },
+        { slug: 'ase-utp', tier: 'community' },
+      ],
+      { talks: ['talk-b'], speakers: ['ana', 'luis'] }
+    ),
+    makeMeetup(
+      '2026-11-19_gamma',
+      '2026-11-19',
+      [{ slug: 'dailybot', tier: 'gold' }],
+      { talks: ['talk-c'], speakers: ['sofia'] }
+    ),
+    makeMeetup('2025-07-10_delta', '2025-07-10', [], {}),
+  ];
+  const editions = [
+    makeEdition(2024, [{ slug: 'dailybot', tier: 'silver' }]),
+    makeEdition(2026, [{ slug: 'ase-utp', tier: 'gold' }]),
+  ];
+
+  it('collects sponsored meetups newest first and splits upcoming from past', () => {
+    const activity = buildSponsorActivity(
+      'dailybot',
+      meetups,
+      editions,
+      [],
+      TODAY
+    );
+
+    expect(activity.meetups.map((m) => m.meetup.id)).toEqual([
+      '2026-11-19_gamma',
+      '2025-04-24_beta',
+      '2024-03-20_alpha',
+    ]);
+    expect(activity.upcomingMeetups.map((m) => m.meetup.id)).toEqual([
+      '2026-11-19_gamma',
+    ]);
+    expect(activity.pastMeetups.map((m) => m.meetup.id)).toEqual([
+      '2025-04-24_beta',
+      '2024-03-20_alpha',
+    ]);
+  });
+
+  it('keeps the per-meetup tier instead of the sponsor default', () => {
+    const activity = buildSponsorActivity(
+      'dailybot',
+      meetups,
+      editions,
+      [],
+      TODAY
+    );
+
+    expect(activity.meetups[0].tier).toBe('gold');
+    expect(activity.meetups[1].tier).toBe('community');
+  });
+
+  it('counts distinct talks and speakers across sponsored meetups', () => {
+    const activity = buildSponsorActivity(
+      'dailybot',
+      meetups,
+      editions,
+      [],
+      TODAY
+    );
+
+    expect(activity.meetupCount).toBe(3);
+    expect(activity.talkCount).toBe(3);
+    // ana appears twice — deduplicated.
+    expect(activity.speakerCount).toBe(3);
+  });
+
+  it('derives the year range from meetups and editions combined', () => {
+    const activity = buildSponsorActivity(
+      'ase-utp',
+      meetups,
+      editions,
+      [],
+      TODAY
+    );
+
+    expect(activity.firstYear).toBe(2025);
+    expect(activity.lastYear).toBe(2026);
+  });
+
+  it('prefers the edition collection tier and backfills orphan years from the sponsor entry', () => {
+    const activity = buildSponsorActivity(
+      'dailybot',
+      meetups,
+      editions,
+      [
+        { year: 2024, tier: 'bronze' },
+        { year: 2019, tier: 'gold' },
+      ],
+      TODAY
+    );
+
+    expect(activity.editions.map((e) => [e.year, e.tier])).toEqual([
+      [2024, 'silver'],
+      [2019, 'gold'],
+    ]);
+    expect(activity.editions[0].edition).toBeDefined();
+    expect(activity.editions[1].edition).toBeUndefined();
+  });
+
+  it('reports an empty activity for logo-only partners', () => {
+    const activity = buildSponsorActivity(
+      'unknown-partner',
+      meetups,
+      editions,
+      [],
+      TODAY
+    );
+
+    expect(activity.isEmpty).toBe(true);
+    expect(activity.meetupCount).toBe(0);
+    expect(activity.firstYear).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

`/sponsors` was a wall of logos where the whole card was an outbound link. The sponsorship data existed — meetups already declare their sponsors — but there was no way to see what any given sponsor actually backed, and clicking a card silently took you off the site.

## What

Every sponsor now has a profile at `/sponsors/{slug}` (`/en/sponsors/{slug}`):

- **Header** — logo, current/past badge, "acompañando a la comunidad desde {year}", `Visitar sitio web ↗` + `Todos los patrocinadores`
- **Stat tiles** — meetups patrocinados · ediciones de PTD · charlas impulsadas · ponentes en escena (each rendered only when > 0)
- **Próximos meetups patrocinados** — only when the sponsor backs a future meetup
- **Meetups patrocinados** — archive grouped by year, newest first
- **Ediciones de Pereira Tech Day** — `EditionCard` per year with the per-edition tier badge
- **Empty state** for logo-only sponsors, plus a sponsorship CTA
- `Organization` JSON-LD with up to 20 sponsored meetups as `subjectOf`

### Derived, never hand-written

`buildSponsorActivity(slug, meetups, editions, sponsoredEditions, today)` is a pure resolver over the *event* side of the graph (`meetups[].sponsors`, `pereiraTechDays[].sponsors`), so the archive and the profiles cannot drift. `sponsoredEditions` on the sponsor entry is now only a fallback for PTD years with no collection entry — which incidentally fixes DailyBot showing 1 edition when it sponsored 2.

Derived counts: DailyBot 13 · ASE-UTP 11 · Aumentada 10 · Vuetify 5 · U. Católica 2 · Cursor 1.

### Link topology

- Sponsor card → profile (primary, internal); the sponsor website is a separate, explicitly marked external link
- Meetup detail sponsor tiles → profile, closing the `meetup ↔ sponsor` loop
- `PtdSponsorsShowcase` keeps its **outbound** logo links — that is a paid edition deliverable and is deliberately untouched

### Vocabulary

Say **patrocinador / sponsor** across this domain, never *aliado / partner* — UI labels, the 15 sponsor YAML descriptions, `/sponsor-us` tiers, and the agent Markdown endpoints. *Aliado* stays reserved for **allied communities** (`/communities`), which are a different relationship and are not sponsors. Documented as a rule in `docs/features/SPONSORS.md`.

## Notes

- The directory carries **no counters** — no aggregate strip, no per-card numbers. It stays a scannable wall of logos whose job is to get you to a profile; the numbers live there, with context.
- `sponsors` is already in the middleware allowlist and nested paths bypass the single-segment rule, so no `src/middleware.ts` change was needed.

## Verification

- `pnpm run test` — 440/440 (6 new cases for `buildSponsorActivity`)
- `pnpm run biome:check` — exit 0
- `pnpm run astro:check` — 0 errors
- `pnpm run build` — 878 pages
- `pnpm run md:check:strict` — 478/478 (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
