### PR TITLE
refactor(verticals): retire the monthly-meetups page and send it to /meetups

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -45,6 +45,28 @@
 /en/pereira-tech-days.md      /en/pereira-tech-day.md       301
 
 # ---------------------------------------------------------------------------
+# Retired vertical page: monthly meetups now live at /meetups
+# ---------------------------------------------------------------------------
+# `/verticals/monthly-meetups` described the programme; `/meetups` carries the
+# full archive, the programming board and the open calls. Two pages for one
+# subject, and the thinner one ranked. The vertical entry survives as a
+# taxonomy term — 95 meetups and several events point at that slug — but its
+# page is no longer generated (`href: /meetups` in the entry).
+#
+# Must sit BEFORE the `/es/*` catch-all below, and point straight at the final
+# URL: Cloudflare does not chain redirects.
+
+/verticals/monthly-meetups        /meetups/                                       301
+/verticals/monthly-meetups/       /meetups/                                       301
+/verticals/monthly-meetups.md     /meetups.md                                     301
+/en/verticals/monthly-meetups     /en/meetups/                                    301
+/en/verticals/monthly-meetups/    /en/meetups/                                    301
+/en/verticals/monthly-meetups.md  /en/meetups.md                                  301
+/es/verticals/monthly-meetups     /meetups/                                       301
+/es/verticals/monthly-meetups/    /meetups/                                       301
+/es/verticals/monthly-meetups.md  /meetups.md                                     301
+
+# ---------------------------------------------------------------------------
 # Language swap: Spanish moved from /es to the site root
 # ---------------------------------------------------------------------------
 # Spanish is the community's primary language and is now served at `/`, with

--- a/src/components/cards/VerticalCard.astro
+++ b/src/components/cards/VerticalCard.astro
@@ -7,6 +7,7 @@ import type { CollectionEntry } from 'astro:content';
 import Badge from '@/components/ui/Badge.astro';
 import { getUrlPrefix, type Language, tr } from '@/lib/i18n';
 import { getTranslations } from '@/lib/translations';
+import { resolveVerticalHref } from '@/lib/vertical';
 
 interface Props {
   vertical: CollectionEntry<'verticals'>;
@@ -19,7 +20,9 @@ const t = getTranslations(lang);
 const prefix = getUrlPrefix(lang);
 const title = tr(vertical.data.title, lang);
 const mission = tr(vertical.data.mission, lang);
-const url = `${prefix}/verticals/${vertical.id}/`;
+// Not always `/verticals/{slug}`: a vertical whose home lives elsewhere —
+// `monthly-meetups` points at `/meetups` — has no generated page to link to.
+const url = resolveVerticalHref(vertical, lang);
 const status = vertical.data.status;
 const statusVariant = status === 'archived' ? 'completed' : 'community';
 const statusLabel =

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -782,6 +782,23 @@ const verticals = defineCollection({
     schedule: i18nStringOptional,
     status: z.enum(['active', 'paused', 'archived']).default('active'),
     order: z.number().default(0),
+    /**
+     * Where this vertical's home page lives, when it is **not**
+     * `/verticals/{slug}`.
+     *
+     * A vertical is two things at once: a taxonomy term that meetups, events
+     * and talks point at, and a page that describes the programme. Usually one
+     * entry serves both. `monthly-meetups` is the exception — `/meetups` is a
+     * fuller page than any generated vertical page could be, so it owns the
+     * description and the vertical keeps only the taxonomy.
+     *
+     * Language-agnostic and root-relative (`/meetups`); the language prefix is
+     * added by `resolveVerticalHref`. Setting it **suppresses** the generated
+     * detail page and its `.md` twin — two pages for one subject is exactly
+     * what this avoids — so add a redirect in `public/_redirects` at the same
+     * time, or the old URL 404s.
+     */
+    href: z.string().startsWith('/').optional(),
   }),
 });
 

--- a/src/content/pages/en/about.md
+++ b/src/content/pages/en/about.md
@@ -22,7 +22,7 @@ The work is sponsor-supported (Veritran, GitHub, ASE-UTP, DailyBot, Aumentada, a
 
 ## What we do
 
-- **[Monthly Meetups](/en/verticals/monthly-meetups)** — In-person and hybrid sessions every month covering AI, web platforms, devops, mobile, security, and the craft of shipping software.
+- **[Monthly Meetups](/en/meetups)** — In-person and hybrid sessions every month covering AI, web platforms, devops, mobile, security, and the craft of shipping software.
 - **[Pereira Tech Day](/en/pereira-tech-day)** — Our flagship annual conference: 2024 archived; [2026 postponed indefinitely](/en/blog/ptd-2026-postponed-earthquake-solidarity/). A full day of keynotes, workshops, and networking with international speakers and local partners.
 - **[Speaker School](/en/verticals/speaker-school)** — A program to grow new technical speakers, from idea to stage, with mentorship, practice runs, and rehearsals.
 - **[La Biblioteca del Mañana](/en/verticals/library-of-tomorrow)** — A reading club connecting science fiction, philosophy, and technology — exploring the future through the books that shape it.

--- a/src/content/pages/es/about.md
+++ b/src/content/pages/es/about.md
@@ -22,7 +22,7 @@ El trabajo se sostiene gracias a patrocinadores (Veritran, GitHub, ASE-UTP, Dail
 
 ## Lo que hacemos
 
-- **[Meetups mensuales](/verticals/monthly-meetups)** — Sesiones presenciales e híbridas cada mes sobre IA, plataformas web, devops, móvil, seguridad y el oficio de publicar software.
+- **[Meetups mensuales](/meetups)** — Sesiones presenciales e híbridas cada mes sobre IA, plataformas web, devops, móvil, seguridad y el oficio de publicar software.
 - **[Pereira Tech Day](/pereira-tech-day)** — Nuestra conferencia anual insignia: 2024 en archivo; [2026 pospuesto indefinidamente](/blog/ptd-2026-postponed-earthquake-solidarity/). Un día completo de keynotes, talleres y networking con ponentes internacionales y aliados locales.
 - **[Escuela de Speakers](/verticals/speaker-school)** — Un programa para hacer crecer nuevas voces técnicas, desde la idea hasta el escenario, con mentoría y ensayos.
 - **[La Biblioteca del Mañana](/verticals/library-of-tomorrow)** — Un club de lectura que conecta ciencia ficción, filosofía y tecnología — explorando el futuro a través de los libros que lo moldean.

--- a/src/content/verticals/monthly-meetups.yaml
+++ b/src/content/verticals/monthly-meetups.yaml
@@ -20,3 +20,9 @@ schedule:
   es: "Tercera semana de cada mes, 6:30 PM hora Pereira."
 status: active
 order: 4
+# The programme's home is /meetups, not a generated vertical page: that page
+# carries the full archive, the programming board and the open calls, and a
+# second page describing the same thing was redundant. The entry stays because
+# 95 meetups and several events point at this slug as a taxonomy term.
+# `public/_redirects` sends the old URL here.
+href: /meetups

--- a/src/lib/agent-resolvers.ts
+++ b/src/lib/agent-resolvers.ts
@@ -21,7 +21,7 @@ import { SITE_URL } from '@/lib/constances';
 import { getContributorsBySlugs } from '@/lib/contributor';
 import { formatCalendarDate, isCalendarDateBeforeToday } from '@/lib/dates';
 import { getUrlPrefix, type Language } from '@/lib/i18n';
-import { resolveI18n } from '@/lib/markdown-for-agents';
+import { mdHref, resolveI18n } from '@/lib/markdown-for-agents';
 import {
   getCallForSpeakersState,
   getMeetupBodyMarkdown,
@@ -47,7 +47,7 @@ import { getSpeakersBySlugs, type Speaker } from '@/lib/speaker';
 import { getEditionSponsors } from '@/lib/sponsor';
 import { getTalksByEvent, getTalksBySpeaker, type Talk } from '@/lib/talk';
 import { getTranslations } from '@/lib/translations';
-import { getVerticals } from '@/lib/vertical';
+import { getVerticals, resolveVerticalTwinHref } from '@/lib/vertical';
 
 /** A talk as an agent-Markdown consumer needs it: nothing left as a slug. */
 export interface ResolvedTalk {
@@ -80,6 +80,14 @@ export interface ResolvedProgramRef {
   slug: string;
   title: string;
   mission: string;
+  /**
+   * Where the program's Markdown twin lives, already language-prefixed.
+   *
+   * Resolved rather than composed from the slug: `monthly-meetups` has no
+   * `/verticals/monthly-meetups.md` — its home is `/meetups.md`. Composing the
+   * path here meant 95 meetup twins linking a page that is no longer generated.
+   */
+  href: string;
 }
 
 export interface ResolvedMeetupDetail {
@@ -454,6 +462,9 @@ export const resolveMeetupDetail = async (
         slug: v,
         title: entry ? resolveI18n(entry.data.title, lang) : v,
         mission: entry ? resolveI18n(entry.data.mission, lang) : '',
+        href: entry
+          ? resolveVerticalTwinHref(entry, lang)
+          : mdHref(lang, `verticals/${v}`),
       };
     }),
     gallery: (meetup.data.gallery ?? []).map((g) => ({

--- a/src/lib/markdown-for-agents.ts
+++ b/src/lib/markdown-for-agents.ts
@@ -795,9 +795,9 @@ export function serializeMeetupDetailToMarkdown(
   if (data.programs.length > 0) {
     sections.push({
       heading: L('programs'),
-      lines: data.programs.map((p) =>
-        entityLine(p.title, mdHref(lang, `verticals/${p.slug}`), p.mission)
-      ),
+      // `p.href`, not a path composed from the slug: a program whose home page
+      // lives elsewhere carries its own twin URL. See `resolveVerticalTwinHref`.
+      lines: data.programs.map((p) => entityLine(p.title, p.href, p.mission)),
     });
   }
 

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -269,7 +269,7 @@ If you are looking for people to grow with, a stage for your first talk, or a co
         description:
           'In-person and hybrid sessions every month — talks, workshops, and lightning rounds on AI, web platforms, devops, mobile, security, and the craft of shipping software.',
         icon: '\u{1F465}',
-        link: '/en/verticals/monthly-meetups',
+        link: '/en/meetups',
       },
       {
         title: 'Pereira Tech Day',

--- a/src/lib/translations/es.ts
+++ b/src/lib/translations/es.ts
@@ -270,7 +270,7 @@ Si buscas gente con quien crecer, un escenario para tu primera charla o una comu
         description:
           'Sesiones presenciales e híbridas cada mes — charlas, talleres y rondas lightning sobre IA, plataformas web, devops, móvil, seguridad y el oficio de publicar software.',
         icon: '\u{1F465}',
-        link: '/verticals/monthly-meetups',
+        link: '/meetups',
       },
       {
         title: 'Pereira Tech Day',

--- a/src/lib/vertical.ts
+++ b/src/lib/vertical.ts
@@ -1,6 +1,6 @@
 import { type CollectionEntry, getCollection } from 'astro:content';
 
-import type { Language } from '@/lib/i18n';
+import { getUrlPrefix, type Language } from '@/lib/i18n';
 
 export type Vertical = CollectionEntry<'verticals'>;
 
@@ -15,6 +15,59 @@ export const getVerticals = async (): Promise<Vertical[]> => {
 export const getActiveVerticals = async (): Promise<Vertical[]> => {
   const all = await getVerticals();
   return all.filter((v) => v.data.status === 'active');
+};
+
+/**
+ * Does this vertical own a generated page at `/verticals/{slug}`?
+ *
+ * False when the entry declares its own `href` — its home lives elsewhere, and
+ * generating a second page for the same subject is what the field exists to
+ * avoid. `getStaticPaths` filters on this, so the route simply does not exist.
+ */
+export const hasGeneratedVerticalPage = (vertical: Vertical): boolean =>
+  !vertical.data.href;
+
+/** The verticals that still get a generated detail page and `.md` twin. */
+export const getVerticalsWithPages = async (): Promise<Vertical[]> => {
+  const all = await getVerticals();
+  return all.filter(hasGeneratedVerticalPage);
+};
+
+/**
+ * Where to link a vertical, in the reader's language.
+ *
+ * `/verticals/{slug}` unless the entry points somewhere else — `monthly-meetups`
+ * sends readers to `/meetups`, which is a fuller page than a generated one
+ * could be. Single source for the card, the home rail, the verticals index and
+ * the agent twins, so a link cannot survive in one place after the page it
+ * pointed at stopped being generated.
+ */
+export const resolveVerticalHref = (
+  vertical: Vertical,
+  lang: Language
+): string => {
+  const prefix = getUrlPrefix(lang);
+  return vertical.data.href
+    ? `${prefix}${vertical.data.href}/`
+    : `${prefix}/verticals/${vertical.id}/`;
+};
+
+/**
+ * The Markdown twin a vertical should link to, in the reader's language.
+ *
+ * The page and its twin move together: a vertical whose home is `/meetups` has
+ * its twin at `/meetups.md`, not at `/verticals/monthly-meetups.md`, which is
+ * no longer generated. `md:check` compares the two surfaces, so a twin link
+ * that outlives its page fails the build rather than rotting quietly.
+ */
+export const resolveVerticalTwinHref = (
+  vertical: Vertical,
+  lang: Language
+): string => {
+  const prefix = getUrlPrefix(lang);
+  return vertical.data.href
+    ? `${prefix}${vertical.data.href}.md`
+    : `${prefix}/verticals/${vertical.id}.md`;
 };
 
 export const getVerticalBySlug = async (

--- a/src/pages/en.md.ts
+++ b/src/pages/en.md.ts
@@ -19,7 +19,7 @@ import {
 import { getUpcomingEdition } from '@/lib/pereiraTechDay';
 import { getActiveSponsors } from '@/lib/sponsor';
 import { getTranslations } from '@/lib/translations';
-import { getActiveVerticals } from '@/lib/vertical';
+import { getActiveVerticals, resolveVerticalTwinHref } from '@/lib/vertical';
 
 /**
  * `/index.md` — the home page.
@@ -109,7 +109,9 @@ export const GET: APIRoute = async () => {
     lines: programs.map((v) =>
       entityLine(
         resolveI18n(v.data.title, lang),
-        mdHref(lang, `verticals/${v.id}`),
+        // Not composed from the slug: a program whose home lives elsewhere
+        // links its own twin. See `resolveVerticalTwinHref`.
+        resolveVerticalTwinHref(v, lang),
         resolveI18n(v.data.mission, lang)
       )
     ),

--- a/src/pages/en/verticals.md.ts
+++ b/src/pages/en/verticals.md.ts
@@ -5,7 +5,7 @@ import {
   resolveI18n,
   serializeGenericToMarkdown,
 } from '@/lib/markdown-for-agents';
-import { getVerticals } from '@/lib/vertical';
+import { getVerticals, resolveVerticalTwinHref } from '@/lib/vertical';
 
 export const GET: APIRoute = async () => {
   const lang = 'en';
@@ -13,7 +13,9 @@ export const GET: APIRoute = async () => {
   const lines = verticals.map((v) => {
     const title = resolveI18n(v.data.title, lang);
     const mission = resolveI18n(v.data.mission, lang);
-    return `- [${title}](/en/verticals/${v.id}.md) — ${mission}`;
+    // Not always `/verticals/{slug}.md` — a vertical whose home lives
+    // elsewhere links its own twin. See `resolveVerticalTwinHref`.
+    return `- [${title}](${resolveVerticalTwinHref(v, lang)}) — ${mission}`;
   });
 
   const markdown = serializeGenericToMarkdown({

--- a/src/pages/en/verticals/[slug].astro
+++ b/src/pages/en/verticals/[slug].astro
@@ -1,9 +1,9 @@
 ---
 import VerticalDetailPage from '@/components/pages/VerticalDetailPage.astro';
-import { getVerticals } from '@/lib/vertical';
+import { getVerticalsWithPages } from '@/lib/vertical';
 
 export async function getStaticPaths() {
-  const verticals = await getVerticals();
+  const verticals = await getVerticalsWithPages();
   return verticals.map((vertical) => ({
     params: { slug: vertical.id },
     props: { vertical },

--- a/src/pages/en/verticals/[slug].md.ts
+++ b/src/pages/en/verticals/[slug].md.ts
@@ -15,10 +15,10 @@ import {
   resolveMeetupVenueLine,
 } from '@/lib/meetup';
 import { getSpeakers } from '@/lib/speaker';
-import { getVerticalBodyEntry, getVerticals } from '@/lib/vertical';
+import { getVerticalBodyEntry, getVerticalsWithPages } from '@/lib/vertical';
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const verticals = await getVerticals();
+  const verticals = await getVerticalsWithPages();
   return Promise.all(
     verticals.map(async (entry) => ({
       params: { slug: entry.id },
@@ -38,7 +38,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const GET: APIRoute = ({ props }) => {
   const lang = 'en';
   const { entry, body, meetups, speakers, channels } = props as {
-    entry: Awaited<ReturnType<typeof getVerticals>>[number];
+    entry: Awaited<ReturnType<typeof getVerticalsWithPages>>[number];
     body: string;
     meetups: Awaited<ReturnType<typeof getMeetupsByVertical>>;
     speakers: Awaited<ReturnType<typeof getSpeakers>>;

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -19,7 +19,7 @@ import {
 import { getUpcomingEdition } from '@/lib/pereiraTechDay';
 import { getActiveSponsors } from '@/lib/sponsor';
 import { getTranslations } from '@/lib/translations';
-import { getActiveVerticals } from '@/lib/vertical';
+import { getActiveVerticals, resolveVerticalTwinHref } from '@/lib/vertical';
 
 /**
  * `/index.md` — the home page.
@@ -108,7 +108,9 @@ export const GET: APIRoute = async () => {
     lines: programs.map((v) =>
       entityLine(
         resolveI18n(v.data.title, lang),
-        mdHref(lang, `verticals/${v.id}`),
+        // Not composed from the slug: a program whose home lives elsewhere
+        // links its own twin. See `resolveVerticalTwinHref`.
+        resolveVerticalTwinHref(v, lang),
         resolveI18n(v.data.mission, lang)
       )
     ),

--- a/src/pages/verticals.md.ts
+++ b/src/pages/verticals.md.ts
@@ -5,7 +5,7 @@ import {
   resolveI18n,
   serializeGenericToMarkdown,
 } from '@/lib/markdown-for-agents';
-import { getVerticals } from '@/lib/vertical';
+import { getVerticals, resolveVerticalTwinHref } from '@/lib/vertical';
 
 export const GET: APIRoute = async () => {
   const lang = 'es';
@@ -13,7 +13,9 @@ export const GET: APIRoute = async () => {
   const lines = verticals.map((v) => {
     const title = resolveI18n(v.data.title, lang);
     const mission = resolveI18n(v.data.mission, lang);
-    return `- [${title}](/verticals/${v.id}.md) — ${mission}`;
+    // Not always `/verticals/{slug}.md` — a vertical whose home lives
+    // elsewhere links its own twin. See `resolveVerticalTwinHref`.
+    return `- [${title}](${resolveVerticalTwinHref(v, lang)}) — ${mission}`;
   });
 
   const markdown = serializeGenericToMarkdown({

--- a/src/pages/verticals/[slug].astro
+++ b/src/pages/verticals/[slug].astro
@@ -1,9 +1,9 @@
 ---
 import VerticalDetailPage from '@/components/pages/VerticalDetailPage.astro';
-import { getVerticals } from '@/lib/vertical';
+import { getVerticalsWithPages } from '@/lib/vertical';
 
 export async function getStaticPaths() {
-  const verticals = await getVerticals();
+  const verticals = await getVerticalsWithPages();
   return verticals.map((vertical) => ({
     params: { slug: vertical.id },
     props: { vertical },

--- a/src/pages/verticals/[slug].md.ts
+++ b/src/pages/verticals/[slug].md.ts
@@ -15,10 +15,10 @@ import {
   resolveMeetupVenueLine,
 } from '@/lib/meetup';
 import { getSpeakers } from '@/lib/speaker';
-import { getVerticalBodyEntry, getVerticals } from '@/lib/vertical';
+import { getVerticalBodyEntry, getVerticalsWithPages } from '@/lib/vertical';
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const verticals = await getVerticals();
+  const verticals = await getVerticalsWithPages();
   return Promise.all(
     verticals.map(async (entry) => ({
       params: { slug: entry.id },
@@ -38,7 +38,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const GET: APIRoute = ({ props }) => {
   const lang = 'es';
   const { entry, body, meetups, speakers, channels } = props as {
-    entry: Awaited<ReturnType<typeof getVerticals>>[number];
+    entry: Awaited<ReturnType<typeof getVerticalsWithPages>>[number];
     body: string;
     meetups: Awaited<ReturnType<typeof getMeetupsByVertical>>;
     speakers: Awaited<ReturnType<typeof getSpeakers>>;

--- a/tests/unit/lib/agent-markdown-completeness.test.ts
+++ b/tests/unit/lib/agent-markdown-completeness.test.ts
@@ -76,6 +76,10 @@ const meetup: ResolvedMeetupDetail = {
       slug: 'monthly-meetups',
       title: 'Monthly meetups',
       mission: 'Consistent monthly meetups in Pereira.',
+      // Not `/en/verticals/monthly-meetups.md`: this program's home is
+      // `/meetups`, and the serializer must link where the resolver points
+      // rather than composing a path from the slug.
+      href: '/en/meetups.md',
     },
   ],
   gallery: [{ src: '/images/g1.webp', alt: 'Audience', caption: 'Full room' }],
@@ -260,7 +264,7 @@ describe('meetup detail serializer', () => {
   it('resolves every entity to a name plus its own `.md`', () => {
     expect(md).toContain('[Juan Alejandro Pérez](/en/speakers/juan-perez.md)');
     expect(md).toContain('[DailyBot](/en/sponsors/dailybot.md)');
-    expect(md).toContain('[Monthly meetups](/en/verticals/monthly-meetups.md)');
+    expect(md).toContain('[Monthly meetups](/en/meetups.md)');
     expect(md).not.toMatch(BARE_SLUG_ROW);
   });
 

--- a/tests/unit/lib/vertical-href.test.ts
+++ b/tests/unit/lib/vertical-href.test.ts
@@ -1,0 +1,94 @@
+/**
+ * A vertical is two things at once: a **taxonomy term** that meetups, events
+ * and talks point at, and a **page** describing the programme. Usually one
+ * entry serves both.
+ *
+ * `monthly-meetups` is the exception. `/meetups` carries the full archive, the
+ * programming board and the open calls — everything a generated vertical page
+ * could say and more — so the page was retired and the term kept: 95 meetups
+ * and several events reference that slug.
+ *
+ * The risk that comes with that split is a link outliving the page it points
+ * at. It nearly happened: the meetup twins composed `/verticals/{slug}.md` from
+ * the slug, so 95 of them would have linked a file the build no longer emits.
+ * These tests pin the rule at its source.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasGeneratedVerticalPage,
+  resolveVerticalHref,
+  resolveVerticalTwinHref,
+  type Vertical,
+} from '@/lib/vertical';
+
+const vertical = (id: string, href?: string): Vertical =>
+  ({ id, data: { ...(href ? { href } : {}) } }) as unknown as Vertical;
+
+describe('a vertical that owns its page', () => {
+  const speakerSchool = vertical('speaker-school');
+
+  it('gets a generated page', () => {
+    expect(hasGeneratedVerticalPage(speakerSchool)).toBe(true);
+  });
+
+  it('links to /verticals/{slug} in both languages', () => {
+    expect(resolveVerticalHref(speakerSchool, 'es')).toBe(
+      '/verticals/speaker-school/'
+    );
+    expect(resolveVerticalHref(speakerSchool, 'en')).toBe(
+      '/en/verticals/speaker-school/'
+    );
+  });
+
+  it('links its twin beside its page', () => {
+    expect(resolveVerticalTwinHref(speakerSchool, 'es')).toBe(
+      '/verticals/speaker-school.md'
+    );
+    expect(resolveVerticalTwinHref(speakerSchool, 'en')).toBe(
+      '/en/verticals/speaker-school.md'
+    );
+  });
+});
+
+describe('a vertical whose home lives elsewhere', () => {
+  const monthlyMeetups = vertical('monthly-meetups', '/meetups');
+
+  it('gets no generated page — that is the point of the field', () => {
+    expect(hasGeneratedVerticalPage(monthlyMeetups)).toBe(false);
+  });
+
+  it('sends readers to its real home, prefixed for their language', () => {
+    expect(resolveVerticalHref(monthlyMeetups, 'es')).toBe('/meetups/');
+    expect(resolveVerticalHref(monthlyMeetups, 'en')).toBe('/en/meetups/');
+  });
+
+  it('sends agents to the twin of that home, not to a file that is gone', () => {
+    expect(resolveVerticalTwinHref(monthlyMeetups, 'es')).toBe('/meetups.md');
+    expect(resolveVerticalTwinHref(monthlyMeetups, 'en')).toBe(
+      '/en/meetups.md'
+    );
+  });
+
+  it('never points at /verticals/{slug} in any form', () => {
+    for (const lang of ['es', 'en'] as const) {
+      expect(resolveVerticalHref(monthlyMeetups, lang)).not.toContain(
+        '/verticals/'
+      );
+      expect(resolveVerticalTwinHref(monthlyMeetups, lang)).not.toContain(
+        '/verticals/'
+      );
+    }
+  });
+});
+
+describe('the page and its twin agree', () => {
+  it('for every vertical, the twin is the page path plus .md', () => {
+    for (const v of [vertical('ai-channel'), vertical('x', '/meetups')]) {
+      for (const lang of ['es', 'en'] as const) {
+        const page = resolveVerticalHref(v, lang).replace(/\/$/, '');
+        expect(resolveVerticalTwinHref(v, lang)).toBe(`${page}.md`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What this does

Retires `/verticals/monthly-meetups` and sends it to `/meetups`.

Two pages described the same programme. The vertical page had a mission, a
schedule and a leader; `/meetups` has the **full archive, the programming board
and the open calls** — everything the vertical page said and considerably more.
The thinner one was redundant, and the two competed for the same searches.

## The part that needed care

A vertical is **two things at once**: a page, and a **taxonomy term**. `95
meetups` and several events carry `verticals: [monthly-meetups]`. Deleting the
entry would have broken every one of those references.

So the entry stays and only the page goes. It declares one new field:

```yaml
href: /meetups
```

Setting it suppresses the generated detail page **and** its `.md` twin — two
pages for one subject is exactly what the field exists to prevent — and it is
the single place that explains why the page is missing.

## Links now resolve, never compose

Every consumer runs through `resolveVerticalHref` / `resolveVerticalTwinHref`:
the vertical card, the home rail, the verticals index, the home twin, and the
meetup twins.

**That last one mattered.** The meetup twins built `/verticals/{slug}.md` by
string-composing the slug, so all **95** of them would have gone on linking a
file the build no longer emits. `md:check` compares a page against its own twin;
it does not follow cross-links, so nothing would have caught it. Found by
grepping the build output rather than by a gate:

```
$ grep -rl "verticals/monthly-meetups" dist
dist/_redirects        ← the only hit, which is where it belongs
```

## Redirects

Both languages, both trailing-slash variants, the `.md` twins, and the legacy
`/es` prefix. Placed **above** the `/es/*` catch-all and pointing straight at
final URLs, because Cloudflare does not chain redirects.

## Also repointed

- the home **"Lo que hacemos" / "What we do"** card;
- both `about.md` agent twins.

## How to QA it

- `/verticals/monthly-meetups` → 301 → `/meetups/` (and `/en/…` → `/en/meetups/`)
- `/verticals/monthly-meetups.md` → 301 → `/meetups.md`
- `/verticals` and `/en/verticals` — the Meetups card links `/meetups`
- `/` — the "Meetups mensuales" card in *Lo que hacemos* links `/meetups`
- any meetup twin, e.g. `/meetups/qa-pilar-del-software.md` — its Programs row
  links `/meetups.md`
- the other three verticals are untouched and still have their own pages

## Numbers

| | before | this branch |
|---|---:|---:|
| Pages built | 898 | **896** |
| Unit tests | 953 | **961** |
| Responsive e2e | 185 | 185 |
| Form e2e | 40 | 40 |

Eight new tests pin the rule, including that a vertical's twin is always its
page path plus `.md` — the invariant whose violation caused the 95 broken links.

All 13 CI steps pass locally, Lighthouse included.

## Risk and rollback

Removing `href` from the entry restores the page and every link with it; the
redirects would then be harmless no-ops pointing at a page that exists again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
